### PR TITLE
Return NODE_NAME_NON_EXISTENT instead of ERROR.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2442,9 +2442,9 @@ static rmw_ret_t get_node_guids(
   if (ret != RMW_RET_OK) {
     return ret;
   } else if (guids.size() == 0) {
-    /* It appears the get_..._by_node operations are supposed to return ERROR if no such node
-       exists */
-    return RMW_RET_ERROR;
+    /* It appears the get_..._by_node operations are supposed to return NODE_NAME_NON_EXISTENT
+       if no such node exists */
+    return RMW_RET_NODE_NAME_NON_EXISTENT;
   } else {
     return RMW_RET_OK;
   }


### PR DESCRIPTION
There are some return value errors in CI test of rcl and rclaction, like [this](http://build.ros2.org/job/Eci__nightly-cyclonedds_ubuntu_bionic_amd64/41/testReport/rcl/TestGraphFixture__rmw_cyclonedds_cpp/test_rcl_get_publisher_names_and_types_by_node/).

I think we should have the return value `RMW_RET_NODE_NAME_NON_EXISTENT` if we can't get the node.

Signed-off-by: evshary <evshary@gmail.com>