### PR TITLE
Use RMW_RET_NODE_NAME_NON_EXISTENT only if defined

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2442,9 +2442,14 @@ static rmw_ret_t get_node_guids(
   if (ret != RMW_RET_OK) {
     return ret;
   } else if (guids.size() == 0) {
-    /* It appears the get_..._by_node operations are supposed to return NODE_NAME_NON_EXISTENT
-       if no such node exists */
+    /* It appears the get_..._by_node operations are supposed to return
+       NODE_NAME_NON_EXISTENT (newly introduced in Eloquent) or ERROR
+       (on Dashing and earlier) if no such node exists */
+#ifdef RMW_RET_NODE_NAME_NON_EXISTENT
     return RMW_RET_NODE_NAME_NON_EXISTENT;
+#else
+    return RMW_RET_ERROR;
+#endif
   } else {
     return RMW_RET_OK;
   }


### PR DESCRIPTION
PR #44 unintentionally introduced a compatibility issue with Dashing and older by switching to the newly introduced ``NODE_NAME_NON_EXISTENT`` error code. For Dashing and older, we need to continue using the generic ``ERROR``. Fortunately they're macros, so a single source base remains possible.