### PR TITLE
Use right event info for RMW_EVENT_LIVELINESS_LOST

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1509,10 +1509,10 @@ extern "C" rmw_ret_t rmw_take_event(
       }
 
     case RMW_EVENT_LIVELINESS_LOST: {
-        auto ei = static_cast<rmw_requested_deadline_missed_status_t *>(event_info);
+        auto ei = static_cast<rmw_liveliness_lost_status_t *>(event_info);
         auto pub = static_cast<CddsPublisher *>(event_handle->data);
-        dds_requested_deadline_missed_status_t st;
-        if (dds_get_requested_deadline_missed_status(pub->pubh, &st) < 0) {
+        dds_liveliness_lost_status_t st;
+        if (dds_get_liveliness_lost_status(pub->pubh, &st) < 0) {
           *taken = false;
           return RMW_RET_ERROR;
         } else {


### PR DESCRIPTION
Looks like a copy-paste mistake

Signed-off-by: Dan Rose <dan@digilabs.io>