### PR TITLE
zero copy api for cyclonedds

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1237,6 +1237,16 @@ extern "C" rmw_ret_t rmw_return_loaned_message_from_publisher(
   return RMW_RET_UNSUPPORTED;
 }
 
+extern "C" rmw_ret_t rmw_return_loaned_message(
+  const rmw_publisher_t * publisher,
+  void * loaned_message)
+{
+  /* https://github.com/ros2/rmw/pull/192 replaces this one with
+     rmw_return_loaned_message_from_publisher, but until that PR is accepted, this one is
+     needed to make things build & work */
+  return rmw_return_loaned_message_from_publisher(publisher, loaned_message);
+}
+
 extern "C" rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 {
   RET_WRONG_IMPLID(node);
@@ -1591,6 +1601,16 @@ extern "C" rmw_ret_t rmw_return_loaned_message_from_subscription(
   RMW_SET_ERROR_MSG(
     "rmw_release_loaned_message_from_subscription not implemented for rmw_cyclonedds_cpp");
   return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_release_loaned_message(
+  const rmw_subscription_t * subscription,
+  void * loaned_message)
+{
+  /* https://github.com/ros2/rmw/pull/192 replaces this one with
+     rmw_return_loaned_message_from_subscription, but until that PR is accepted, this one
+     is needed to make things build & work */
+  return rmw_return_loaned_message_from_subscription(subscription, loaned_message);
 }
 
 extern "C" rmw_ret_t rmw_take_event(

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -802,6 +802,19 @@ extern "C" rmw_ret_t rmw_publish_serialized_message(
   return ok ? RMW_RET_OK : RMW_RET_ERROR;
 }
 
+extern "C" rmw_ret_t rmw_publish_loaned_message(
+  const rmw_publisher_t * publisher,
+  void * ros_message,
+  rmw_publisher_allocation_t * allocation)
+{
+  (void) publisher;
+  (void) ros_message;
+  (void) allocation;
+
+  RMW_SET_ERROR_MSG("rmw_publish_loaned_message not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
 static const rosidl_message_type_support_t * get_typesupport(
   const rosidl_message_type_support_t * type_supports)
 {
@@ -1199,6 +1212,31 @@ rmw_ret_t rmw_publisher_get_actual_qos(const rmw_publisher_t * publisher, rmw_qo
   }
 }
 
+extern "C" rmw_ret_t rmw_borrow_loaned_message(
+  const rmw_publisher_t * publisher,
+  const rosidl_message_type_support_t * type_support,
+  void ** ros_message)
+{
+  (void) publisher;
+  (void) type_support;
+  (void) ros_message;
+
+  RMW_SET_ERROR_MSG("rmw_borrow_loaned_message not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_return_loaned_message_from_publisher(
+  const rmw_publisher_t * publisher,
+  void * loaned_message)
+{
+  (void) publisher;
+  (void) loaned_message;
+
+  RMW_SET_ERROR_MSG(
+    "rmw_return_loaned_message_from_publisher not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
 extern "C" rmw_ret_t rmw_destroy_publisher(rmw_node_t * node, rmw_publisher_t * publisher)
 {
   RET_WRONG_IMPLID(node);
@@ -1509,6 +1547,50 @@ extern "C" rmw_ret_t rmw_take_serialized_message_with_info(
 {
   static_cast<void>(allocation);
   return rmw_take_ser_int(subscription, serialized_message, taken, message_info);
+}
+
+extern "C" rmw_ret_t rmw_take_loaned_message(
+  const rmw_subscription_t * subscription,
+  void ** loaned_message,
+  bool * taken,
+  rmw_subscription_allocation_t * allocation)
+{
+  (void) subscription;
+  (void) loaned_message;
+  (void) taken;
+  (void) allocation;
+
+  RMW_SET_ERROR_MSG("rmw_take_loaned_message not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_take_loaned_message_with_info(
+  const rmw_subscription_t * subscription,
+  void ** loaned_message,
+  bool * taken,
+  rmw_message_info_t * message_info,
+  rmw_subscription_allocation_t * allocation)
+{
+  (void) subscription;
+  (void) loaned_message;
+  (void) taken;
+  (void) message_info;
+  (void) allocation;
+
+  RMW_SET_ERROR_MSG("rmw_take_loaned_message_with_info not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
+}
+
+extern "C" rmw_ret_t rmw_return_loaned_message_from_subscription(
+  const rmw_subscription_t * subscription,
+  void * loaned_message)
+{
+  (void) subscription;
+  (void) loaned_message;
+
+  RMW_SET_ERROR_MSG(
+    "rmw_release_loaned_message_from_subscription not implemented for rmw_cyclonedds_cpp");
+  return RMW_RET_UNSUPPORTED;
 }
 
 extern "C" rmw_ret_t rmw_take_event(


### PR DESCRIPTION
addresses the missing functions for zero-copy API as noted in here: https://github.com/ros2/ros2/issues/785#issuecomment-544337245

Connects to https://github.com/ros2/rclcpp/pull/896

Signed-off-by: Karsten Knese <karsten@openrobotics.org>