### PR TITLE
Make RMW version acceptable to MSVC

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -63,13 +63,10 @@
 
 /* True if the version of RMW is at least major.minor.patch */
 #define RMW_VERSION_GTE(major, minor, patch) ( \
-    (major < RMW_VERSION_MAJOR) ? true \
-    : (major > RMW_VERSION_MAJOR) ? false \
-    : (minor < RMW_VERSION_MINOR) ? true \
-    : (minor > RMW_VERSION_MINOR) ? false \
-    : (patch < RMW_VERSION_PATCH) ? true \
-    : (patch > RMW_VERSION_PATCH) ? false \
-    : true)
+    major < RMW_VERSION_MAJOR || ( \
+      major == RMW_VERSION_MAJOR && ( \
+        minor < RMW_VERSION_MINOR || ( \
+          minor == RMW_VERSION_MINOR && patch <= RMW_VERSION_PATCH))))
 
 /* Set to > 0 for printing warnings to stderr for each messages that was taken more than this many
    ms after writing */


### PR DESCRIPTION
GCC and Clang support the ternary operator in macros, MSVC does not.

Signed-off-by: Erik Boasson <eb@ilities.com>