### PR TITLE
Suppress a syntax error identified by cppcheck 1.89

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1743,6 +1743,7 @@ extern "C" rmw_wait_set_t * rmw_create_wait_set(rmw_context_t * context, size_t 
   RET_ALLOC_X(wait_set->data, goto fail_alloc_wait_set_data);
   // This should default-construct the fields of CddsWaitset
   ws = static_cast<CddsWaitset *>(wait_set->data);
+  // cppcheck-suppress syntaxError
   RMW_TRY_PLACEMENT_NEW(ws, ws, goto fail_placement_new, CddsWaitset, );
   if (!ws) {
     RMW_SET_ERROR_MSG("failed to construct wait set info struct");


### PR DESCRIPTION
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8567)](http://ci.ros2.org/job/ci_linux/8567/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4442)](http://ci.ros2.org/job/ci_linux-aarch64/4442/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6988)](http://ci.ros2.org/job/ci_osx/6988/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8485)](http://ci.ros2.org/job/ci_windows/8485/) <- Expected Failure