### PR TITLE
Use rcutils_get_env() instead of getenv() (#71)

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -24,8 +24,8 @@
 #include <utility>
 #include <regex>
 
-#include "rcutils/logging_macros.h"
 #include "rcutils/get_env.h"
+#include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
 
 #include "rmw/allocators.h"


### PR DESCRIPTION
@dirk-thomas there's this:

https://github.com/ros2/rcutils/blob/540d9472b0c7de4b029f2e26f3388e3b9a5bb1eb/include/rcutils/get_env.h#L52

There is no way of knowing who will be calling ``rcutils_get_env`` or when, so I think this limitation is asking for trouble. I presume this has been considered in the past and deemed acceptable, and if so (and assuming my change gets through review and test build) feel free to simply merge it.

Signed-off-by: Erik Boasson <eb@ilities.com>