### PR TITLE
Serialize into uninitialized memory, not vector

### DIFF
--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -91,14 +91,18 @@ struct DataCursor : public CDRCursor
   : origin(position), position(position) {}
 
   size_t offset() const final {return (const byte *)position - (const byte *)origin;}
-  void advance(size_t n_bytes) final {position = byte_offset(position, n_bytes);}
+  void advance(size_t n_bytes) final
+  {
+    std::memset(position, '\0', n_bytes);
+    position = byte_offset(position, n_bytes);
+  }
   void put_bytes(const void * bytes, size_t n_bytes) final
   {
     if (n_bytes == 0) {
       return;
     }
     std::memcpy(position, bytes, n_bytes);
-    advance(n_bytes);
+    position = byte_offset(position, n_bytes);
   }
   bool ignores_data() const final {return false;}
   void rebase(ptrdiff_t relative_origin) final {origin = byte_offset(origin, relative_origin);}

--- a/rmw_cyclonedds_cpp/src/Serialization.hpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.hpp
@@ -15,8 +15,8 @@
 #define SERIALIZATION_HPP_
 
 #include "TypeSupport2.hpp"
-#include "rmw_cyclonedds_cpp/serdata.hpp"
 #include "rosidl_generator_c/service_type_support_struct.h"
+#include "serdata.hpp"
 
 namespace rmw_cyclonedds_cpp
 {

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -54,7 +54,7 @@
 #include "dds/dds.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "rmw_cyclonedds_cpp/serdes.hpp"
-#include "rmw_cyclonedds_cpp/serdata.hpp"
+#include "serdata.hpp"
 
 /* Proper multi-domain support requires eliminating the "extra" participant, which in turn relies on
    the promotion of the Cyclone DDS library instance and the daomsin to full-fledged entities.  The
@@ -1651,15 +1651,15 @@ static rmw_ret_t rmw_take_ser_int(
         memcpy(message_info->publisher_gid.data, &info.publication_handle,
           sizeof(info.publication_handle));
       }
-      auto d = static_cast<struct serdata_rmw *>(dcmn);
+      auto d = static_cast<serdata_rmw *>(dcmn);
       /* FIXME: what about the header - should be included or not? */
-      if (rmw_serialized_message_resize(serialized_message, d->data.size()) != RMW_RET_OK) {
+      if (rmw_serialized_message_resize(serialized_message, d->size()) != RMW_RET_OK) {
         ddsi_serdata_unref(dcmn);
         *taken = false;
         return RMW_RET_ERROR;
       }
-      memcpy(serialized_message->buffer, d->data.data(), d->data.size());
-      serialized_message->buffer_length = d->data.size();
+      memcpy(serialized_message->buffer, d->data(), d->size());
+      serialized_message->buffer_length = d->size();
       ddsi_serdata_unref(dcmn);
       *taken = true;
       return RMW_RET_OK;

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -11,23 +11,22 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#ifndef RMW_CYCLONEDDS_CPP__SERDATA_HPP_
-#define RMW_CYCLONEDDS_CPP__SERDATA_HPP_
+#ifndef SERDATA_HPP_
+#define SERDATA_HPP_
 
 #include <memory>
 #include <string>
-#include <vector>
 
+#include "bytewise.hpp"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+#include "TypeSupport2.hpp"
 
 struct CddsTypeSupport
 {
   void * type_support_;
   const char * typesupport_identifier_;
 };
-
-namespace rmw_cyclonedds_cpp {class StructValueType;}
 
 struct sertopic_rmw : ddsi_sertopic
 {
@@ -41,11 +40,19 @@ struct sertopic_rmw : ddsi_sertopic
   std::unique_ptr<const rmw_cyclonedds_cpp::StructValueType> value_type;
 };
 
-struct serdata_rmw : ddsi_serdata
+class serdata_rmw : public ddsi_serdata
 {
+protected:
+  uint32_t m_size {0};
   /* first two bytes of data is CDR encoding
      second two bytes are encoding options */
-  std::vector<unsigned char> data;
+  std::unique_ptr<byte[]> m_data {nullptr};
+
+public:
+  serdata_rmw(const ddsi_sertopic * topic, ddsi_serdata_kind kind);
+  void resize(uint32_t requested_size);
+  uint32_t size() const {return m_size;}
+  void * data() const {return m_data.get();}
 };
 
 typedef struct cdds_request_header
@@ -79,4 +86,4 @@ struct ddsi_serdata * serdata_rmw_from_serialized_message(
   const struct ddsi_sertopic * topiccmn,
   const void * raw, size_t size);
 
-#endif  // RMW_CYCLONEDDS_CPP__SERDATA_HPP_
+#endif  // SERDATA_HPP_


### PR DESCRIPTION
Also make serdata a private header
Reduces overall latency on ApexAI benchmark by about 10%