### PR TITLE
Stubs for rmw_get_publishers_info_by_topic and rmw_get_subscriptions_info_by_topic

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -50,7 +50,7 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 add_library(rmw_cyclonedds_cpp
   src/rmw_node.cpp
-  src/rmw_get_topic_info.cpp
+  src/rmw_get_topic_endpoint_info.cpp
   src/serdata.cpp
   src/serdes.cpp
   src/graphrhc.cpp

--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -50,6 +50,7 @@ ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 
 add_library(rmw_cyclonedds_cpp
   src/rmw_node.cpp
+  src/rmw_get_topic_info.cpp
   src/serdata.cpp
   src/serdes.cpp
   src/graphrhc.cpp

--- a/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -13,8 +13,8 @@
 // limitations under the License.
 
 #include "rmw/error_handling.h"
-#include "rmw/get_topic_info.h"
-#include "rmw/topic_info_array.h"
+#include "rmw/get_topic_endpoint_info.h"
+#include "rmw/topic_endpoint_info_array.h"
 
 extern "C"
 {
@@ -24,7 +24,7 @@ rmw_get_publishers_info_by_topic(
   rcutils_allocator_t * /* unused_param */,
   const char * /* unused_param */,
   bool /* unused_param */,
-  rmw_topic_info_array_t * /* unused_param */)
+  rmw_topic_endpoint_info_array_t * /* unused_param */)
 {
   return RMW_RET_UNSUPPORTED;
 }
@@ -35,7 +35,7 @@ rmw_get_subscriptions_info_by_topic(
   rcutils_allocator_t * /* unused_param */,
   const char * /* unused_param */,
   bool /* unused_param */,
-  rmw_topic_info_array_t * /* unused_param */)
+  rmw_topic_endpoint_info_array_t * /* unused_param */)
 {
   return RMW_RET_UNSUPPORTED;
 }

--- a/rmw_cyclonedds_cpp/src/rmw_get_topic_info.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_get_topic_info.cpp
@@ -1,0 +1,42 @@
+// Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rmw/error_handling.h"
+#include "rmw/get_topic_info.h"
+#include "rmw/topic_info_array.h"
+
+extern "C"
+{
+rmw_ret_t
+rmw_get_publishers_info_by_topic(
+  const rmw_node_t * /* unused_param */,
+  rcutils_allocator_t * /* unused_param */,
+  const char * /* unused_param */,
+  bool /* unused_param */,
+  rmw_topic_info_array_t * /* unused_param */)
+{
+  return RMW_RET_UNSUPPORTED;
+}
+
+rmw_ret_t
+rmw_get_subscriptions_info_by_topic(
+  const rmw_node_t * /* unused_param */,
+  rcutils_allocator_t * /* unused_param */,
+  const char * /* unused_param */,
+  bool /* unused_param */,
+  rmw_topic_info_array_t * /* unused_param */)
+{
+  return RMW_RET_UNSUPPORTED;
+}
+}  // extern "C"


### PR DESCRIPTION
**NOTE: DO NOT MERGE until https://github.com/ros2/rmw/pull/186 and https://github.com/ros2/rmw_implementation/pull/72 are merged.**

Leaving stubs for `rmw_get_publishers_info_by_topic()` and `rmw_get_subscriptions_info_by_topic()`.

Related to [aws-roadmap#94](https://app.zenhub.com/workspaces/aws-robotics-open-source-roadmap-5d9662bf4e1ec400011c53c6/issues/ros-security/aws-roadmap/94).