### PR TITLE
rmw_get_topic_endpoint_info doesn't exist on Dashing

### DIFF
--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/rmw_version_test.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/rmw_version_test.hpp
@@ -1,0 +1,24 @@
+// Copyright 2019 ADLINK Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef RMW_CYCLONEDDS_CPP__RMW_VERSION_TEST_HPP_
+#define RMW_CYCLONEDDS_CPP__RMW_VERSION_TEST_HPP_
+
+/* True if the version of RMW is at least major.minor.patch */
+#define RMW_VERSION_GTE(major, minor, patch) ( \
+    major < RMW_VERSION_MAJOR || ( \
+      major == RMW_VERSION_MAJOR && ( \
+        minor < RMW_VERSION_MINOR || ( \
+          minor == RMW_VERSION_MINOR && patch <= RMW_VERSION_PATCH))))
+
+#endif  // RMW_CYCLONEDDS_CPP__RMW_VERSION_TEST_HPP_

--- a/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -14,7 +14,7 @@
 
 #include "rmw_cyclonedds_cpp/rmw_version_test.hpp"
 
-#if RMW_VERSION_GTE(0, 8, 1)
+#if RMW_VERSION_GTE(0, 8, 2)
 
 #include "rmw/error_handling.h"
 #include "rmw/get_topic_endpoint_info.h"

--- a/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_get_topic_endpoint_info.cpp
@@ -12,6 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rmw_cyclonedds_cpp/rmw_version_test.hpp"
+
+#if RMW_VERSION_GTE(0, 8, 1)
+
 #include "rmw/error_handling.h"
 #include "rmw/get_topic_endpoint_info.h"
 #include "rmw/topic_endpoint_info_array.h"
@@ -40,3 +44,5 @@ rmw_get_subscriptions_info_by_topic(
   return RMW_RET_UNSUPPORTED;
 }
 }  // extern "C"
+
+#endif

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -46,6 +46,7 @@
 
 #include "TypeSupport2.hpp"
 
+#include "rmw_cyclonedds_cpp/rmw_version_test.hpp"
 #include "rmw_cyclonedds_cpp/MessageTypeSupport.hpp"
 #include "rmw_cyclonedds_cpp/ServiceTypeSupport.hpp"
 
@@ -65,13 +66,6 @@
 #else
 #define MULTIDOMAIN 0
 #endif
-
-/* True if the version of RMW is at least major.minor.patch */
-#define RMW_VERSION_GTE(major, minor, patch) ( \
-    major < RMW_VERSION_MAJOR || ( \
-      major == RMW_VERSION_MAJOR && ( \
-        minor < RMW_VERSION_MINOR || ( \
-          minor == RMW_VERSION_MINOR && patch <= RMW_VERSION_PATCH))))
 
 #if RMW_VERSION_GTE(0, 8, 1) && MULTIDOMAIN
 #define SUPPORT_LOCALHOST 1


### PR DESCRIPTION
... and this PR avoids trying to compile them on Dashing, similarly to how other RMW interface changes have been dealt with in the Cyclone DDS RMW layer so far.

Signed-off-by: Erik Boasson <eb@ilities.com>