### PR TITLE
Correct std::hash return type sizes

### DIFF
--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -465,8 +465,10 @@ bool sertopic_rmw_equal(
 uint32_t sertopic_rmw_hash(const struct ddsi_sertopic * tpcmn)
 {
   const struct sertopic_rmw * tp = static_cast<const struct sertopic_rmw *>(tpcmn);
-  uint32_t h2 = std::hash<bool>{} (tp->is_request_header);
-  uint32_t h1 = std::hash<std::string>{} (std::string(tp->type_support.typesupport_identifier_));
+  uint32_t h2 = static_cast<uint32_t>(std::hash<bool>{} (tp->is_request_header));
+  uint32_t h1 =
+    static_cast<uint32_t>(std::hash<std::string>{} (std::string(
+      tp->type_support.typesupport_identifier_)));
   return h1 ^ h2;
 }
 #endif


### PR DESCRIPTION
Corrects recent build warnings in CI (for example https://ci.ros2.org/view/packaging/job/packaging_windows/1648/), because `std::hash` returns a `size_t`

```
serdata.cpp:468, MSBuild, Priority: Normal
--
'initializing': conversion from 'size_t' to 'uint32_t', possible loss of data
```

Signed-off-by: Michael Carroll <michael@openrobotics.org>