### PR TITLE
Use a list instead of a set for node names list

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2884,14 +2884,14 @@ extern "C" rmw_ret_t rmw_get_node_names(
     return RMW_RET_ERROR;
   }
 
-  std::set<std::pair<std::string, std::string>> ns;
+  std::vector<std::pair<std::string, std::string>> ns;
   const auto re = std::regex("^name=(.*);namespace=(.*);$", std::regex::extended);
   auto oper =
     [&ns, re](const dds_builtintopic_participant_t & sample, const char * ud) -> bool {
       std::cmatch cm;
       static_cast<void>(sample);
       if (std::regex_search(ud, cm, re)) {
-        ns.insert(std::make_pair(std::string(cm[1]), std::string(cm[2])));
+        ns.push_back(std::make_pair(std::string(cm[1]), std::string(cm[2])));
       }
       return true;
     };


### PR DESCRIPTION
The other rmw implementations currently return all node names, even if there are duplicates. This behavior allows us to reason about there being duplicate nodes in the system and warn the user about it, even if we can't solve it. Using the `std::set` only masks this potentially confusing case.

Unblocks https://github.com/ros2/ros2cli/pull/463
Related to https://github.com/ros2/ros2cli/issues/453
Related to https://github.com/ros-tooling/aws-roadmap/issues/196

Signed-off-by: Emerson Knapp <emerson.b.knapp@gmail.com>