### PR TITLE
Prevent undefined behavior when serializing empty vector

### DIFF
--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -245,6 +245,8 @@ public:
   }
   const void * sequence_contents(const void * ptr_to_sequence) const override
   {
+    if(sequence_size(ptr_to_sequence) == 0)
+      return nullptr;
     return m_get_const_function(ptr_to_sequence, 0);
   }
 };


### PR DESCRIPTION
Since m_get_const_function calls `std::vector<T>::operator[]`, accessing the zeroth element causes undefined behavior. Instead, return a null pointer to make the function behave sanely when vector is empty.
Fix #120
