### PR TITLE
Enable use of Cyclone DDS security features

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Cyclone DDS is ready to use. It seeks to give the fastest, easiest, and most rob
 
 ## Building from source and contributing
 
-
 Note the `master` branch maintains compatibility with ROS releases Dashing and later, including the not-yet-released [*Foxy*](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/).
 
 If building ROS2 from source ([ros2.repos](https://github.com/ros2/ros2/blob/master/ros2.repos)), you already have this package and Cyclone DDS:

--- a/README.md
+++ b/README.md
@@ -30,6 +30,5 @@ DDS directly instead of via the ROS2 abstraction.
 
 ## Known limitations
 
-Cyclone DDS doesn't yet implement the DDS Security standard, nor does it fully implement
-the Lifespan, Deadline and some of the Liveliness QoS modes.  Consequently these features
-of ROS2 are also not yet supported when using Cyclone DDS.
+Cyclone DDS doesn't yet fully implement the Lifespan, Deadline and some of the Liveliness QoS modes.
+Consequently these features of ROS2 are also not yet supported when using Cyclone DDS.

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -147,6 +147,18 @@ struct builtin_readers
   dds_entity_t rds[sizeof(builtin_topics) / sizeof(builtin_topics[0])];
 };
 
+#if RMW_SUPPORT_SECURITY
+struct dds_security_files_t
+{
+  char * identity_ca_cert = nullptr;
+  char * cert = nullptr;
+  char * key = nullptr;
+  char * permissions_ca_cert = nullptr;
+  char * governance_p7s = nullptr;
+  char * permissions_p7s = nullptr;
+};
+#endif
+
 struct CddsEntity
 {
   dds_entity_t enth;
@@ -653,81 +665,108 @@ static std::string get_node_user_data(const char * node_name, const char * node_
 
 #if RMW_SUPPORT_SECURITY
 /*  Returns the full URI of a security file properly formatted for DDS  */
-char * get_security_file_URI(
-  const char * security_filename, const char * node_secure_root,
+bool get_security_file_URI(
+  char ** security_file, const char * security_filename, const char * node_secure_root,
   const rcutils_allocator_t allocator)
 {
-  char * ret;
-
+  *security_file = nullptr;
   char * file_path = rcutils_join_path(node_secure_root, security_filename, allocator);
-  if (file_path == nullptr) {
-    ret = nullptr;
-  } else if (!rcutils_is_readable(file_path)) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rmw_cyclonedds_cpp", "get_security_file: %s not found", file_path);
-    ret = nullptr;
-    allocator.deallocate(file_path, allocator.state);
-  } else {
-    /*  Cyclone also supports a "data:" URI  */
-    ret = rcutils_format_string(allocator, "file:%s", file_path);
-    allocator.deallocate(file_path, allocator.state);
+  if (file_path != nullptr) {
+    if (rcutils_is_readable(file_path)) {
+      /*  Cyclone also supports a "data:" URI  */
+      *security_file = rcutils_format_string(allocator, "file:%s", file_path);
+      allocator.deallocate(file_path, allocator.state);
+    } else {
+      RCUTILS_LOG_INFO_NAMED(
+        "rmw_cyclonedds_cpp", "get_security_file_URI: %s not found", file_path);
+      allocator.deallocate(file_path, allocator.state);
+    }
+  }
+  return *security_file != nullptr;
+}
+
+bool get_security_file_URIs(
+  const rmw_node_security_options_t * security_options,
+  dds_security_files_t & dds_security_files, rcutils_allocator_t allocator)
+{
+  bool ret = false;
+
+  if (security_options->security_root_path != nullptr) {
+    ret = (
+      get_security_file_URI(
+        &dds_security_files.identity_ca_cert, "identity_ca.cert.pem",
+        security_options->security_root_path, allocator) &&
+      get_security_file_URI(
+        &dds_security_files.cert, "cert.pem",
+        security_options->security_root_path, allocator) &&
+      get_security_file_URI(
+        &dds_security_files.key, "key.pem",
+        security_options->security_root_path, allocator) &&
+      get_security_file_URI(
+        &dds_security_files.permissions_ca_cert, "permissions_ca.cert.pem",
+        security_options->security_root_path, allocator) &&
+      get_security_file_URI(
+        &dds_security_files.governance_p7s, "governance.p7s",
+        security_options->security_root_path, allocator) &&
+      get_security_file_URI(
+        &dds_security_files.permissions_p7s, "permissions.p7s",
+        security_options->security_root_path, allocator));
   }
   return ret;
 }
 
-void store_security_filepath_in_qos(
-  dds_qos_t * qos, const char * qos_property_name, const char * file_name,
-  const rmw_node_security_options_t * security_options)
+void finalize_security_file_URIs(
+  dds_security_files_t dds_security_files, const rcutils_allocator_t allocator)
 {
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
-
-  char * security_file_path = get_security_file_URI(
-    file_name, security_options->security_root_path, allocator);
-  if (security_file_path != nullptr) {
-    dds_qset_prop(qos, qos_property_name, security_file_path);
-    allocator.deallocate(security_file_path, allocator.state);
-  }
+  allocator.deallocate(dds_security_files.identity_ca_cert, allocator.state);
+  dds_security_files.identity_ca_cert = nullptr;
+  allocator.deallocate(dds_security_files.cert, allocator.state);
+  dds_security_files.cert = nullptr;
+  allocator.deallocate(dds_security_files.key, allocator.state);
+  dds_security_files.key = nullptr;
+  allocator.deallocate(dds_security_files.permissions_ca_cert, allocator.state);
+  dds_security_files.permissions_ca_cert = nullptr;
+  allocator.deallocate(dds_security_files.governance_p7s, allocator.state);
+  dds_security_files.governance_p7s = nullptr;
+  allocator.deallocate(dds_security_files.permissions_p7s, allocator.state);
+  dds_security_files.permissions_p7s = nullptr;
 }
+
 #endif  /* RMW_SUPPORT_SECURITY */
 
-/*  Set all the qos properties needed to enable DDS security  */
+/* Attempt to set all the qos properties needed to enable DDS security */
 rmw_ret_t configure_qos_for_security(
   dds_qos_t * qos, const rmw_node_security_options_t * security_options)
 {
 #if RMW_SUPPORT_SECURITY
-  /*  File path is set to nullptr if file does not exist or is not readable  */
-  store_security_filepath_in_qos(
-    qos, "dds.sec.auth.identity_ca", "identity_ca.cert.pem",
-    security_options);
-  store_security_filepath_in_qos(
-    qos, "dds.sec.auth.identity_certificate", "cert.pem",
-    security_options);
-  store_security_filepath_in_qos(
-    qos, "dds.sec.auth.private_key", "key.pem",
-    security_options);
-  store_security_filepath_in_qos(
-    qos, "dds.sec.access.permissions_ca", "permissions_ca.cert.pem",
-    security_options);
-  store_security_filepath_in_qos(
-    qos, "dds.sec.access.governance", "governance.p7s",
-    security_options);
-  store_security_filepath_in_qos(
-    qos, "dds.sec.access.permissions", "permissions.p7s",
-    security_options);
+  rmw_ret_t ret = RMW_RET_UNSUPPORTED;
+  dds_security_files_t dds_security_files;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
-  dds_qset_prop(qos, "dds.sec.auth.library.path", "dds_security_auth");
-  dds_qset_prop(qos, "dds.sec.auth.library.init", "init_authentication");
-  dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_authentication");
+  if (get_security_file_URIs(security_options, dds_security_files, allocator)) {
+    dds_qset_prop(qos, "dds.sec.auth.identity_ca", dds_security_files.identity_ca_cert);
+    dds_qset_prop(qos, "dds.sec.auth.identity_certificate", dds_security_files.cert);
+    dds_qset_prop(qos, "dds.sec.auth.private_key", dds_security_files.key);
+    dds_qset_prop(qos, "dds.sec.access.permissions_ca", dds_security_files.permissions_ca_cert);
+    dds_qset_prop(qos, "dds.sec.access.governance", dds_security_files.governance_p7s);
+    dds_qset_prop(qos, "dds.sec.access.permissions", dds_security_files.permissions_p7s);
 
-  dds_qset_prop(qos, "dds.sec.crypto.library.path", "dds_security_crypto");
-  dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_crypto");
-  dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_crypto");
+    dds_qset_prop(qos, "dds.sec.auth.library.path", "dds_security_auth");
+    dds_qset_prop(qos, "dds.sec.auth.library.init", "init_authentication");
+    dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_authentication");
 
-  dds_qset_prop(qos, "dds.sec.access.library.path", "dds_security_ac");
-  dds_qset_prop(qos, "dds.sec.access.library.init", "init_access_control");
-  dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_access_control");
+    dds_qset_prop(qos, "dds.sec.crypto.library.path", "dds_security_crypto");
+    dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_crypto");
+    dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_crypto");
 
-  return RMW_RET_OK;
+    dds_qset_prop(qos, "dds.sec.access.library.path", "dds_security_ac");
+    dds_qset_prop(qos, "dds.sec.access.library.init", "init_access_control");
+    dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_access_control");
+
+    ret = RMW_RET_OK;
+  }
+  finalize_security_file_URIs(dds_security_files, allocator);
+  return ret;
 #else
   (void) qos;
   (void) security_options;
@@ -795,11 +834,14 @@ extern "C" rmw_node_t * rmw_create_node(
   std::string user_data = get_node_user_data(name, namespace_);
   dds_qset_userdata(qos, user_data.c_str(), user_data.size());
 
-  if (security_options->enforce_security) {
-    if (configure_qos_for_security(qos, security_options) != RMW_RET_OK) {
+  if (configure_qos_for_security(qos, security_options) != RMW_RET_OK) {
+    if (security_options->enforce_security == RMW_SECURITY_ENFORCEMENT_ENFORCE) {
       dds_delete_qos(qos);
       node_gone_from_domain_locked(did);
       return nullptr;
+    } else {
+      RCUTILS_LOG_INFO_NAMED(
+        "rmw_cyclonedds_cpp", "rmw_create_node: Unable to configure security");
     }
   }
 

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -27,10 +27,10 @@
 #include <regex>
 
 #include "rcutils/filesystem.h"
+#include "rcutils/format_string.h"
 #include "rcutils/get_env.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
-#include "rcutils/format_string.h"
 
 #include "rmw/allocators.h"
 #include "rmw/convert_rcutils_ret_to_rmw_ret.h"
@@ -61,6 +61,7 @@
 #include "namespace_prefix.hpp"
 
 #include "dds/dds.h"
+#include "dds/ddsc/dds_public_qos.h"
 #include "dds/ddsi/ddsi_sertopic.h"
 #include "rmw_cyclonedds_cpp/serdes.hpp"
 #include "serdata.hpp"
@@ -79,6 +80,13 @@
 #define SUPPORT_LOCALHOST 1
 #else
 #define SUPPORT_LOCALHOST 0
+#endif
+
+/* Security must be enabled when compiling and requires cyclone to support QOS property lists */
+#if DDS_HAS_SECURITY && DDS_HAS_PROPERTY_LIST_QOS
+#define RMW_SUPPORT_SECURITY 1
+#else
+#define RMW_SUPPORT_SECURITY 0
 #endif
 
 /* Set to > 0 for printing warnings to stderr for each messages that was taken more than this many
@@ -644,6 +652,7 @@ static std::string get_node_user_data(const char * node_name, const char * node_
          std::string(";");
 }
 
+#if RMW_SUPPORT_SECURITY
 /*  Returns the full URI of a security file properly formatted for DDS  */
 char * get_security_file_URI(
   const char * security_filename, const char * node_secure_root,
@@ -680,11 +689,14 @@ void store_security_filepath_in_qos(
     allocator.deallocate(security_file_path, allocator.state);
   }
 }
+#endif  /* RMW_SUPPORT_SECURITY */
 
 /*  Set all the qos properties needed to enable DDS security  */
-void configure_qos_for_security(
+rmw_ret_t configure_qos_for_security(
   dds_qos_t * qos, const rmw_node_security_options_t * security_options)
 {
+
+#if RMW_SUPPORT_SECURITY
   /*  File path is set to nullptr if file does not exist or is not readable  */
   store_security_filepath_in_qos(
     qos, "dds.sec.auth.identity_ca", "identity_ca.cert.pem",
@@ -705,17 +717,28 @@ void configure_qos_for_security(
     qos, "dds.sec.access.permissions", "permissions.p7s",
     security_options);
 
-  dds_qset_prop(qos, "dds.sec.auth.library.path", "libdds_security_auth.so");
+  dds_qset_prop(qos, "dds.sec.auth.library.path", "dds_security_auth");
   dds_qset_prop(qos, "dds.sec.auth.library.init", "init_authentication");
   dds_qset_prop(qos, "dds.sec.auth.library.finalize", "finalize_authentication");
 
-  dds_qset_prop(qos, "dds.sec.crypto.library.path", "libdds_security_crypto.so");
+  dds_qset_prop(qos, "dds.sec.crypto.library.path", "dds_security_crypto");
   dds_qset_prop(qos, "dds.sec.crypto.library.init", "init_crypto");
   dds_qset_prop(qos, "dds.sec.crypto.library.finalize", "finalize_crypto");
 
-  dds_qset_prop(qos, "dds.sec.access.library.path", "libdds_security_ac.so");
+  dds_qset_prop(qos, "dds.sec.access.library.path", "dds_security_ac");
   dds_qset_prop(qos, "dds.sec.access.library.init", "init_access_control");
   dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_access_control");
+
+  return RMW_RET_OK;
+#else
+  (void) qos;
+  (void) security_options;
+  RMW_SET_ERROR_MSG(
+    "Security was requested but the Cyclone DDS being used does not have security "
+    "support enabled. Recompile Cyclone DDS with the '-DENABLE_SECURITY=ON' "
+    "CMake option");
+  return RMW_RET_UNSUPPORTED;
+#endif
 }
 
 extern "C" rmw_node_t * rmw_create_node(
@@ -743,11 +766,7 @@ extern "C" rmw_node_t * rmw_create_node(
   const dds_domainid_t did = DDS_DOMAIN_DEFAULT;
 #endif
 
-  if (security_options == nullptr) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rmw_cyclonedds_cpp", "rmw_create_node: security options null");
-    return nullptr;
-  }
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(security_options, nullptr);
 
   rmw_ret_t ret;
   int dummy_validation_result;
@@ -770,16 +789,15 @@ extern "C" rmw_node_t * rmw_create_node(
 #endif
 
   dds_qos_t * qos = dds_create_qos();
-  if (qos == nullptr) {
-    RCUTILS_LOG_ERROR_NAMED(
-      "rmw_cyclonedds_cpp", "rmw_create_node: Unable to create qos");
-    return nullptr;
-  }
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(
+    security_options, "rmw_create_node: Unable to create qos", return nullptr);
   std::string user_data = get_node_user_data(name, namespace_);
   dds_qset_userdata(qos, user_data.c_str(), user_data.size());
 
   if (security_options->enforce_security) {
-    configure_qos_for_security(qos, security_options);
+    if (configure_qos_for_security(qos, security_options) != RMW_RET_OK) {
+      return nullptr;
+    }
   }
 
   dds_entity_t pp = dds_create_participant(did, qos, nullptr);


### PR DESCRIPTION
Add utility function to insert security settings to the cyclone QOS object used to create nodes. Include a utility to find security files and properly format their location to use with DDS.

Code testing included running the ROS2 tutorials with encryption enabled, error checking for missing certificates, testing bad signatures on governance and permissions files, invalid or mismatched domain IDs, and invalid encryption keys.