### PR TITLE
correct fallthrough macro

### DIFF
--- a/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
+++ b/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
@@ -15,7 +15,7 @@
 #ifndef FALLTHROUGH_MACRO_HPP_
 #define FALLTHROUGH_MACRO_HPP_
 
-#if __has_cpp_attribute(fallthrough) && (__cplusplus >= 201703L)
+#if __cplusplus >= 201603L
 // C++17
 #define FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(clang::fallthrough)

--- a/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
+++ b/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
@@ -15,7 +15,7 @@
 #ifndef FALLTHROUGH_MACRO_HPP_
 #define FALLTHROUGH_MACRO_HPP_
 
-#if __has_cpp_attribute(fallthrough) || (__cplusplus >= 201603L)
+#if __has_cpp_attribute(fallthrough) && (__cplusplus >= 201703L)
 // C++17
 #define FALLTHROUGH [[fallthrough]]
 #elif __has_cpp_attribute(clang::fallthrough)

--- a/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
+++ b/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
@@ -26,7 +26,7 @@
 #define FALLTHROUGH [[gnu::fallthrough]]
 #else
 // gcc
-#define FALLTHROUGH __attribute__ ((fallthrough));
+#define FALLTHROUGH /* FALLTHROUGH */
 #endif
 
 #endif  // FALLTHROUGH_MACRO_HPP_

--- a/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
+++ b/rmw_cyclonedds_cpp/src/fallthrough_macro.hpp
@@ -21,9 +21,12 @@
 #elif __has_cpp_attribute(clang::fallthrough)
 // Clang
 #define FALLTHROUGH [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+// gcc with gnu extension
+#define FALLTHROUGH [[gnu::fallthrough]]
 #else
 // gcc
-#define FALLTHROUGH /* fallthrough */
+#define FALLTHROUGH __attribute__ ((fallthrough));
 #endif
 
 #endif  // FALLTHROUGH_MACRO_HPP_


### PR DESCRIPTION
The current fallthrough macro gave me a warning now on OSX when compiling with `-Werror`:

```
error: use of the 'fallthrough' attribute is a C++17 extension [-Werror,-Wc++17-extensions]
      FALLTHROUGH;
```

The reason, as far as I can tell, is that the compiler is c++17 enabled, yet we're compiling the project with a C++14 standard. 
Also I think there was a typo when choosing the compiler version for 17, according to
https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
> 201703L for the 2017 C++ standard 

EDIT: ~Looking into a default behavior for gcc7, I found this: https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/ and applied the `__attribute__  ((fallthrough))`~
As to be expected, MSVC doesn't know that attribute. Going back to comment as default behavior.

@rotu let me know what you think