### PR TITLE
Provide a dummy readcdr function if needed

### DIFF
--- a/rmw_cyclonedds_cpp/src/graphrhc.cpp
+++ b/rmw_cyclonedds_cpp/src/graphrhc.cpp
@@ -118,6 +118,26 @@ static int graphrhc_take(
   return 0;
 }
 
+#if DDS_HAS_READCDR
+static int graphrhc_readcdr(
+  struct dds_rhc * rhc_cmn, bool lock, struct ddsi_serdata ** values,
+  dds_sample_info_t * info_seq, uint32_t max_samples,
+  uint32_t sample_states, uint32_t view_states, uint32_t instance_states,
+  dds_instance_handle_t handle)
+{
+  static_cast<void>(rhc_cmn);
+  static_cast<void>(lock);
+  static_cast<void>(values);
+  static_cast<void>(info_seq);
+  static_cast<void>(max_samples);
+  static_cast<void>(sample_states);
+  static_cast<void>(view_states);
+  static_cast<void>(instance_states);
+  static_cast<void>(handle);
+  return 0;
+}
+#endif
+
 static int graphrhc_takecdr(
   struct dds_rhc * rhc_cmn, bool lock, struct ddsi_serdata ** values,
   dds_sample_info_t * info_seq, uint32_t max_samples,
@@ -165,6 +185,9 @@ static const struct dds_rhc_ops graphrhc_ops = {
   },
   graphrhc_read,
   graphrhc_take,
+#if DDS_HAS_READCDR
+  graphrhc_readcdr,
+#endif
   graphrhc_takecdr,
   graphrhc_add_readcondition,
   graphrhc_remove_readcondition,


### PR DESCRIPTION
Current master has a custom reader history cache (RHC) for monitoring the changes to the node graph without having to waste memory on it. https://github.com/eclipse-cyclonedds/cyclonedds/pull/499 at long last adds a companion `dds_readcdr` to the existing `dds_takecdr` that this RMW layer has depended on for a long time, and so the custom RHC needs to updated with a trivial implementation.

#145 changes the mapping of ROS nodes to participants and uses the "graph cache" implemented in `rmw_dds_common`. In that setting, there is no use for this custom RHC and so this PR doesn't apply after #145 has been merged.