### PR TITLE
Exclude other RMW from Github CI build

### DIFF
--- a/.github/resources/suppress_other_rmw.repos
+++ b/.github/resources/suppress_other_rmw.repos
@@ -1,0 +1,11 @@
+definitions:
+  - &empty_repo
+    type: zip
+    url: data:application/zip;base64,UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==
+
+repositories:
+  ros2/rosidl_typesupport_connext/COLCON_IGNORE: *empty_repo
+  ros2/rmw_connext/COLCON_IGNORE: *empty_repo
+
+  ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
+  ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,9 +13,11 @@ jobs:
       # azure ubuntu repo can be flaky so add an alternate source
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
     - name: Acquire ROS dependencies
-      uses: ros-tooling/setup-ros@0.0.19
+      uses: ros-tooling/setup-ros@0.0.20
     - name: Build and test ROS
-      uses: ros-tooling/action-ros-ci@0.0.15
+      uses: ros-tooling/action-ros-ci@0.0.16
       with:
         package-name: rmw_cyclonedds_cpp
-        vcs-repo-file-url: https://raw.githubusercontent.com/ros2/ros2/${{ matrix.rosdistro }}/ros2.repos
+        vcs-repo-file-url: >
+          https://raw.githubusercontent.com/ros2/ros2/${{ matrix.rosdistro }}/ros2.repos
+          https://raw.githubusercontent.com/${{github.repository}}/${{github.sha}}/.github/resources/suppress_other_rmw.repos


### PR DESCRIPTION
Since #145, the CI build of rmw_cyclonedds_cpp has been failing on Windows due to inadvertently injecting fastrtps into the build process.
fastrtps fails to build (https://github.com/eProsima/Fast-RTPS/issues/1173) causing the CI to fail.
There doesn't seem to be a better way to suppress this in action-ros-ci https://github.com/ros-tooling/action-ros-ci/issues/177

Fixes #164