### PR TITLE
Provide a dummy readcdr function if needed

### DIFF
--- a/rmw_cyclonedds_cpp/src/graphrhc.cpp
+++ b/rmw_cyclonedds_cpp/src/graphrhc.cpp
@@ -118,6 +118,26 @@ static int graphrhc_take(
   return 0;
 }
 
+#if DDS_HAS_READCDR
+static int graphrhc_readcdr(
+  struct dds_rhc * rhc_cmn, bool lock, struct ddsi_serdata ** values,
+  dds_sample_info_t * info_seq, uint32_t max_samples,
+  uint32_t sample_states, uint32_t view_states, uint32_t instance_states,
+  dds_instance_handle_t handle)
+{
+  static_cast<void>(rhc_cmn);
+  static_cast<void>(lock);
+  static_cast<void>(values);
+  static_cast<void>(info_seq);
+  static_cast<void>(max_samples);
+  static_cast<void>(sample_states);
+  static_cast<void>(view_states);
+  static_cast<void>(instance_states);
+  static_cast<void>(handle);
+  return 0;
+}
+#endif
+
 static int graphrhc_takecdr(
   struct dds_rhc * rhc_cmn, bool lock, struct ddsi_serdata ** values,
   dds_sample_info_t * info_seq, uint32_t max_samples,
@@ -165,6 +185,9 @@ static const struct dds_rhc_ops graphrhc_ops = {
   },
   graphrhc_read,
   graphrhc_take,
+#if DDS_HAS_READCDR
+  graphrhc_readcdr,
+#endif
   graphrhc_takecdr,
   graphrhc_add_readcondition,
   graphrhc_remove_readcondition,


### PR DESCRIPTION
The RMW layer in dashing/eloquent depends on a still-evolving interface for custom reader history caches in Cyclone. https://github.com/eclipse-cyclonedds/cyclonedds/pull/499 extends that interface, this PR ensures the sources in the RMW layer will be compatible with Cyclone also after merging that PR.

I believe future proofing by a change of this nature makes sense anyway, but a mishap in implementing #142 means dashing today still relies on cyclonedds' master branch (it is a good thing Cyclone DDS regressions are pretty rare!). Therefore, https://github.com/eclipse-cyclonedds/cyclonedds/pull/499 can only go into Cyclone after either this PR, or https://github.com/ros2/ros2/pull/907 or both have been merged.

Note that Eloquent and Foxy are "safe": Eloquent because it uses cyclonedds:releases/0.5.x and Foxy because #145 removed the reliance on this interface.