### PR TITLE
Reset security related RMW error state.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -922,6 +922,8 @@ extern "C" rmw_ret_t rmw_init(const rmw_init_options_t * options, rmw_context_t 
     if (context->options.security_options.enforce_security == RMW_SECURITY_ENFORCEMENT_ENFORCE) {
       return RMW_RET_ERROR;
     }
+    // No security enforced, lack of support is not an error.
+    rmw_reset_error();
   }
   impl->ppant = dds_create_participant(domain_id, ppant_qos.get(), nullptr);
   if (impl->ppant < 0) {


### PR DESCRIPTION
If security support is not required, the lack of it is not an error. I think this was introduced in #145.

Without this patch, if building with `ENABLE_SECURITY=off` and  `RCUTILS_REPORT_ERROR_HANDLING_ERRORS` set, the error string set in `configure_qos_security()` is always printed out on any downstream override.