### PR TITLE
Address error message

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -851,11 +851,12 @@ rmw_ret_t configure_qos_for_security(
   return ret;
 #else
   (void) qos;
-  (void) security_options;
-  RMW_SET_ERROR_MSG(
-    "Security was requested but the Cyclone DDS being used does not have security "
-    "support enabled. Recompile Cyclone DDS with the '-DENABLE_SECURITY=ON' "
-    "CMake option");
+  if (security_options->enforce_security == RMW_SECURITY_ENFORCEMENT_ENFORCE) {
+    RMW_SET_ERROR_MSG(
+      "Security was requested but the Cyclone DDS being used does not have security "
+      "support enabled. Recompile Cyclone DDS with the '-DENABLE_SECURITY=ON' "
+      "CMake option");
+  }
   return RMW_RET_UNSUPPORTED;
 #endif
 }


### PR DESCRIPTION
Only generate the error "Recompile with '-DENABLESECURITY=ON' error when not compiled with security and the environment variable ROS_SECURITY_STRATEGY="Enforce". Addresses https://github.com/ros2/rmw_cyclonedds/pull/123#discussion_r416883418 and https://github.com/ros2/rmw_cyclonedds/pull/172#discussion_r416892363.

Signed-off-by: Sid Faber <sid.faber@canonical.com>