### PR TITLE
Initialize participant on first use. Destroy participant after last node is destroyed.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -280,11 +280,10 @@ struct rmw_context_impl_t
   ~rmw_context_impl_t()
   {
     if (0u != this->node_count) {
-      fprintf(
-        stderr,
+      RCUTILS_SAFE_FWRITE_TO_STDERR(
         "Not all nodes were finished before finishing the context\n."
         "Ensure `rcl_node_fini` is called for all nodes before `rcl_context_fini`,"
-        "to avoid leaking.");
+        "to avoid leaking.\n");
     }
   }
 
@@ -948,7 +947,6 @@ rmw_context_impl_t::init(rmw_init_options_t * options)
       "rmw_cyclonedds_cpp", "rmw_create_node: failed to create DCPSPublication reader");
     return RMW_RET_ERROR;
   }
-
   /* Create DDS publisher/subscriber objects that will be used for all DDS writers/readers
     to be created for RMW publishers/subscriptions. */
   if ((this->dds_pub = dds_create_publisher(this->ppant, nullptr, nullptr)) < 0) {

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -283,7 +283,8 @@ struct rmw_context_impl_t
       fprintf(
         stderr,
         "Not all nodes were finished before finishing the context\n."
-        "Ensure `rcl_node_fini` is called for all nodes before `rcl_context_fini`, to avoid leaking.");
+        "Ensure `rcl_node_fini` is called for all nodes before `rcl_context_fini`,"
+        "to avoid leaking.");
     }
   }
 };

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2690,7 +2690,8 @@ extern "C" rmw_ret_t rmw_trigger_guard_condition(
 
 extern "C" rmw_wait_set_t * rmw_create_wait_set(rmw_context_t * context, size_t max_conditions)
 {
-  (void) max_conditions;
+  (void)context;
+  (void)max_conditions;
   rmw_wait_set_t * wait_set = rmw_wait_set_allocate();
   CddsWaitset * ws = nullptr;
   RET_ALLOC_X(wait_set, goto fail_alloc_wait_set);
@@ -2717,7 +2718,7 @@ extern "C" rmw_wait_set_t * rmw_create_wait_set(rmw_context_t * context, size_t 
     std::lock_guard<std::mutex> lock(gcdds.lock);
     // Lazily create dummy guard condition
     if (gcdds.waitsets.size() == 0) {
-      if ((gcdds.gc_for_empty_waitset = dds_create_guardcondition(context->impl->ppant)) < 0) {
+      if ((gcdds.gc_for_empty_waitset = dds_create_guardcondition(DDS_CYCLONEDDS_HANDLE)) < 0) {
         RMW_SET_ERROR_MSG("failed to create guardcondition for handling empty waitsets");
         goto fail_create_dummy;
       }

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -883,6 +883,7 @@ rmw_context_impl_t::init(rmw_init_options_t * options)
   std::lock_guard<std::mutex> guard(initialization_mutex);
   if (0u != this->node_count) {
     // initialization has already been done
+    this->node_count++;
     return RMW_RET_OK;
   }
 


### PR DESCRIPTION
The same approach was used in `rmw_fastrtps`.
Fixes https://github.com/ros2/rmw_cyclonedds/issues/174.