### PR TITLE
Fix topic name mangling when not using ros conventions

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1392,7 +1392,7 @@ static std::string make_fqtopic(
   bool avoid_ros_namespace_conventions)
 {
   if (avoid_ros_namespace_conventions) {
-    return std::string(topic_name) + "__" + std::string(suffix);
+    return std::string(topic_name) + std::string(suffix);
   } else {
     return std::string(prefix) + std::string(topic_name) + std::string(suffix);
   }


### PR DESCRIPTION
Fixes https://github.com/ros2/system_tests/pull/428.