### PR TITLE
CI: switch setup-ros to master

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
       # azure ubuntu repo can be flaky so add an alternate source
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
     - name: Acquire ROS dependencies
-      uses: ros-tooling/setup-ros@0.0.20
+      uses: ros-tooling/setup-ros@master
     - name: Build and test ROS
       uses: ros-tooling/action-ros-ci@0.0.16
       with:


### PR DESCRIPTION
Master has build-fixing changes for compatibility with the GitHub Windows runner since https://github.com/ros-tooling/setup-ros/pull/159