### PR TITLE
fix serialisation on 64-bit, big-endian systems: dashing-eloquent

### DIFF
--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -299,8 +299,9 @@ protected:
   void serialize_u32(CDRCursor * cursor, size_t value) const
   {
     assert(value <= std::numeric_limits<uint32_t>::max());
+    auto u32_value = static_cast<uint32_t>(value);
     cursor->align(4);
-    cursor->put_bytes(&value, 4);
+    cursor->put_bytes(&u32_value, 4);
   }
 
   static size_t get_cdr_size_of_primitive(ROSIDL_TypeKind tk)


### PR DESCRIPTION
Serialization issue reported in [eclipse-cyclonedds/cyclonedds#488](https://github.com/eclipse-cyclonedds/cyclonedds/issues/488).

This same patch was merged with `master` in PR #159.

Discussion about merging with `dashing-eloquent` in Issue #188.