### PR TITLE
Restore dashing/eloquent behaviour of "service_is_available"

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3636,9 +3636,9 @@ extern "C" rmw_ret_t rmw_service_server_is_available(
     dds_get_subscription_matched_status(info->client.sub->enth, &cs) < 0)
   {
     RMW_SET_ERROR_MSG("rmw_service_server_is_available: get_..._matched_status failed");
+    return RMW_RET_ERROR;
   }
-  // all conditions met, there is a service server available
-  *is_available = true;
+  *is_available = ps.current_count > 0 && cs.current_count > 0;
   return RMW_RET_OK;
 }
 

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3628,7 +3628,6 @@ extern "C" rmw_ret_t rmw_service_server_is_available(
   ret =
     common_context->graph_cache.get_writer_count(sub_topic_name, &number_of_response_publishers);
   if (ret != RMW_RET_OK || 0 == number_of_response_publishers) {
-    // error
     return ret;
   }
   dds_publication_matched_status_t ps;


### PR DESCRIPTION
This "mostly fixes" the lost service responses (#183, #74) by reinstating the check for a matching reader and writer in `rmw_service_server_is_available` that was accidentally deleted when the 1:1 mapping of nodes to participants was replaced by a 1:1 mapping of contexts to participants. This effectively restores dashing/eloquent behaviour.

It doesn't truly fix the problem and in the presence of packet loss the likelihood of failure remains significant. However, the workaround proposed in #187 is a bit controversial and this restoration of the old code at least should be non-controversial.