### PR TITLE
Add space between 'ROS' and '2'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: ROS2 CI
+name: ROS 2 CI
 on: [push, pull_request]
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# ROS2 RMW for Eclipse Cyclone DDS
+# ROS 2 RMW for Eclipse Cyclone DDS
 
-**Easy, fast, reliable, small [Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds) middleware** for ROS2. Make your **🐢 run like a 🚀** [Eclipse Cyclone DDS has great adopters](https://iot.eclipse.org/adopters/) and contributors in the ROS community and is an [Eclipse Foundation](https://www.eclipse.org) open source project of [Eclipse IoT](https://iot.eclipse.org) and [OpenADx](https://openadx.eclipse.org) (autonomous driving).
+**Easy, fast, reliable, small [Eclipse Cyclone DDS](https://github.com/eclipse-cyclonedds/cyclonedds) middleware** for ROS 2. Make your **🐢 run like a 🚀** [Eclipse Cyclone DDS has great adopters](https://iot.eclipse.org/adopters/) and contributors in the ROS community and is an [Eclipse Foundation](https://www.eclipse.org) open source project of [Eclipse IoT](https://iot.eclipse.org) and [OpenADx](https://openadx.eclipse.org) (autonomous driving).
 
-This package lets [*ROS2*](https://index.ros.org/doc/ros2) use [*Eclipse Cyclone DDS*](https://github.com/eclipse-cyclonedds/cyclonedds) as the underlying DDS implementation.
-Cyclone DDS is ready to use. It seeks to give the fastest, easiest, and most robust ROS2 experience. Let the Cyclone blow you away!
+This package lets [*ROS 2*](https://index.ros.org/doc/ros2) use [*Eclipse Cyclone DDS*](https://github.com/eclipse-cyclonedds/cyclonedds) as the underlying DDS implementation.
+Cyclone DDS is ready to use. It seeks to give the fastest, easiest, and most robust ROS 2 experience. Let the Cyclone blow you away!
 
 1. Install:
 
@@ -15,7 +15,7 @@ Cyclone DDS is ready to use. It seeks to give the fastest, easiest, and most rob
    apt install ros-dashing-rmw-cyclonedds-cpp
    ```
 
-2. Set env variable and run ROS2 apps as usual:
+2. Set env variable and run ROS 2 apps as usual:
 
    ```export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp```
 
@@ -63,7 +63,7 @@ The following branches are actively maintained:
 * `master`, which targets the upcoming ROS version, [*Foxy*](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/).
 * `dashing-eloquent`, which maintains compatibility with ROS releases [*Dashing*](https://index.ros.org/doc/ros2/Releases/Release-Dashing-Diademata/) and [*Eloquent*](https://index.ros.org/doc/ros2/Releases/Release-Eloquent-Elusor/)
 
-If building ROS2 from source ([ros2.repos](https://github.com/ros2/ros2/blob/master/ros2.repos)), you already have this package and Cyclone DDS:
+If building ROS 2 from source ([ros2.repos](https://github.com/ros2/ros2/blob/master/ros2.repos)), you already have this package and Cyclone DDS:
 
     cd /opt/ros/master
     rosdep install --from src -i

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -255,7 +255,7 @@ struct rmw_context_impl_t
   dds_entity_t rd_subscription;
   dds_entity_t rd_publication;
 
-  /* DDS publisher, subscriber used for ROS2 publishers and subscriptions */
+  /* DDS publisher, subscriber used for ROS 2 publishers and subscriptions */
   dds_entity_t dds_pub;
   dds_entity_t dds_sub;
 

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -201,7 +201,7 @@ static struct ddsi_serdata * serdata_rmw_from_sample(
     const struct sertopic_rmw * topic = static_cast<const struct sertopic_rmw *>(topiccmn);
     auto d = std::make_unique<serdata_rmw>(topic, kind);
     if (kind != SDK_DATA) {
-      /* ROS2 doesn't do keys, so SDK_KEY is trivial */
+      /* ROS 2 doesn't do keys, so SDK_KEY is trivial */
     } else if (!topic->is_request_header) {
       size_t sz = topic->cdr_writer->get_serialized_size(sample);
       d->resize(sz);
@@ -275,7 +275,7 @@ static bool serdata_rmw_to_sample(
     assert(bufptr == NULL);
     assert(buflim == NULL);
     if (d->kind != SDK_DATA) {
-      /* ROS2 doesn't do keys in a meaningful way yet */
+      /* ROS 2 doesn't do keys in a meaningful way yet */
     } else if (!topic->is_request_header) {
       cycdeser sd(d->data(), d->size());
       if (using_introspection_c_typesupport(topic->type_support.typesupport_identifier_)) {
@@ -325,7 +325,7 @@ static bool serdata_rmw_topicless_to_sample(
   static_cast<void>(sample);
   static_cast<void>(bufptr);
   static_cast<void>(buflim);
-  /* ROS2 doesn't do keys in a meaningful way yet */
+  /* ROS 2 doesn't do keys in a meaningful way yet */
   return true;
 }
 
@@ -333,7 +333,7 @@ static bool serdata_rmw_eqkey(const struct ddsi_serdata * a, const struct ddsi_s
 {
   static_cast<void>(a);
   static_cast<void>(b);
-  /* ROS2 doesn't do keys in a meaningful way yet */
+  /* ROS 2 doesn't do keys in a meaningful way yet */
   return true;
 }
 
@@ -345,7 +345,7 @@ static size_t serdata_rmw_print(
     auto d = static_cast<const serdata_rmw *>(dcmn);
     const struct sertopic_rmw * topic = static_cast<const struct sertopic_rmw *>(tpcmn);
     if (d->kind != SDK_DATA) {
-      /* ROS2 doesn't do keys in a meaningful way yet */
+      /* ROS 2 doesn't do keys in a meaningful way yet */
       return static_cast<size_t>(snprintf(buf, bufsize, ":k:{}"));
     } else if (!topic->is_request_header) {
       cycprint sd(buf, bufsize, d->data(), d->size());
@@ -394,7 +394,7 @@ static void serdata_rmw_get_keyhash(
   const struct ddsi_serdata * d, struct ddsi_keyhash * buf,
   bool force_md5)
 {
-  /* ROS2 doesn't do keys in a meaningful way yet, this is never called for topics without
+  /* ROS 2 doesn't do keys in a meaningful way yet, this is never called for topics without
      key fields */
   static_cast<void>(d);
   static_cast<void>(force_md5);


### PR DESCRIPTION
For the proper use of "ROS 2" :grin:

I modified more than just the README, hope you don't mind.

Also, if someone could fix the repo description, that would be nice

> **ROS2** RMW layer for Eclipse Cyclone DDS