### PR TITLE
Bump CI version

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,8 +5,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          rosdistro: [master]
-          os: [ubuntu-18.04, macOS-latest, windows-latest]
+          rosdistro: [rolling]
+          os: [ubuntu-18.04, ubuntu-20.04, macOS-latest, windows-latest]
+          include:
+          - rosdistro: rolling
+            repos_branch: master
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Windows'
@@ -21,11 +24,13 @@ jobs:
     - name: Acquire ROS dependencies
       uses: ros-tooling/setup-ros@master
     - name: Build and test ROS
-      uses: ros-tooling/action-ros-ci@0.0.16
+      id: ros_ci
+      uses: ros-tooling/action-ros-ci@0.0.19
       with:
         package-name: >
           rmw_cyclonedds_cpp
           rmw_implementation
+        target-ros2-distro: ${{matrix.rosdistro}}
         vcs-repo-file-url: >
-          https://raw.githubusercontent.com/ros2/ros2/${{ matrix.rosdistro }}/ros2.repos
+          https://raw.githubusercontent.com/ros2/ros2/${{ matrix.repos_branch }}/ros2.repos
           https://raw.githubusercontent.com/${{github.repository}}/${{github.sha}}/.github/resources/suppress_other_rmw.repos


### PR DESCRIPTION
Bring CI up to date and add Ubuntu 20.04, the current target platform for ROS Rolling.