### PR TITLE
Fix memory leak that string not deleted.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -551,13 +551,21 @@ static void handle_ParticipantEntitiesInfo(dds_entity_t reader, void * arg)
 {
   static_cast<void>(reader);
   rmw_context_impl_t * impl = static_cast<rmw_context_impl_t *>(arg);
-  auto msg = std::unique_ptr<ParticipantEntitiesInfo>(new ParticipantEntitiesInfo);
   bool taken;
-  while (rmw_take(impl->common.sub, msg.get(), &taken, nullptr) == RMW_RET_OK && taken) {
-    // locally published data is filtered because of the subscription QoS
-    impl->common.graph_cache.update_participant_entities(*msg.get());
-    msg.reset();
-  }
+  do {
+    // TODO(iuhilnehc-ynos): Fix memory leak that string not deleted. (#224)
+    // This is a workaround to make sure calling destructor of ParticipantEntitiesInfo
+    // after calling rmw_take each time, otherwise, there will be a memory leak while
+    // deserializing a long enough buffer into a string member of NodeEntitiesInfo
+    // in ParticipantEntitiesInfo.
+    ParticipantEntitiesInfo msg;
+    if (rmw_take(impl->common.sub, &msg, &taken, nullptr) == RMW_RET_OK && taken) {
+      // locally published data is filtered because of the subscription QoS
+      impl->common.graph_cache.update_participant_entities(msg);
+    } else {
+      break;
+    }
+  } while (1);
 }
 
 static void handle_DCPSParticipant(dds_entity_t reader, void * arg)

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -551,11 +551,12 @@ static void handle_ParticipantEntitiesInfo(dds_entity_t reader, void * arg)
 {
   static_cast<void>(reader);
   rmw_context_impl_t * impl = static_cast<rmw_context_impl_t *>(arg);
-  ParticipantEntitiesInfo msg;
+  auto msg = std::unique_ptr<ParticipantEntitiesInfo>(new ParticipantEntitiesInfo);
   bool taken;
-  while (rmw_take(impl->common.sub, &msg, &taken, nullptr) == RMW_RET_OK && taken) {
+  while (rmw_take(impl->common.sub, msg.get(), &taken, nullptr) == RMW_RET_OK && taken) {
     // locally published data is filtered because of the subscription QoS
-    impl->common.graph_cache.update_participant_entities(msg);
+    impl->common.graph_cache.update_participant_entities(*msg.get());
+    msg.reset();
   }
 }
 


### PR DESCRIPTION
Related to ros2/rcl#721

<details><summary>memory leak log</summary>
<p>

```shell
==23528== 29 bytes in 1 blocks are definitely lost in loss record 1 of 72
==23528==    at 0x4C3017F: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==23528==    by 0x1DAA6A: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) (basic_string.tcc:219)
==23528==    by 0x5D45786: cycdeser::deserialize(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (serdes.hpp:165)
==23528==    by 0x5D450F4: cycdeser::operator>>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&) (serdes.hpp:113)
==23528==    by 0x5D4657B: void rmw_cyclonedds_cpp::deserialize_field<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(rosidl_typesupport_introspection_cpp::MessageMember const*, void*, cycdeser&, bool) (TypeSupport_impl.hpp:281)
==23528==    by 0x5D503D6: rmw_cyclonedds_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::deserializeROSmessage(cycdeser&, rosidl_typesupport_introspection_cpp::MessageMembers const*, void*, bool) (TypeSupport_impl.hpp:514)
==23528==    by 0x5D5051A: rmw_cyclonedds_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::deserializeROSmessage(cycdeser&, rosidl_typesupport_introspection_cpp::MessageMembers const*, void*, bool) (TypeSupport_impl.hpp:542)
==23528==    by 0x5D4AA30: rmw_cyclonedds_cpp::TypeSupport<rosidl_typesupport_introspection_cpp::MessageMembers>::deserializeROSmessage(cycdeser&, void*, std::function<void (cycdeser&)>) (TypeSupport_impl.hpp:669)
==23528==    by 0x5D9734E: serdata_rmw_to_sample(ddsi_serdata const*, void*, void**, void*) (serdata.cpp:288)
==23528==    by 0x80CD643: ddsi_serdata_to_sample (ddsi_serdata.h:230)
==23528==    by 0x814B813: read_take_to_sample (dds_rhc_default.c:1956)
==23528==    by 0x814BF68: take_w_qminv_inst (dds_rhc_default.c:2091)
```

</p>
</details>

The patch is to make sure deleting ParticipantEntitiesInfo after calling `rmw_take` each time.

Signed-off-by: Chen.Lihui <lihui.chen@sony.com>