### PR TITLE
Use correct functions to resize and get an item, avoiding memory leaks in typesupport code

### DIFF
--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport.hpp
@@ -98,12 +98,9 @@ struct StringHelper<rosidl_typesupport_introspection_cpp::MessageMembers>
     return *(static_cast<std::string *>(data));
   }
 
-  static void assign(cycdeser & deser, void * field, bool call_new)
+  static void assign(cycdeser & deser, void * field)
   {
     std::string & str = *(std::string *)field;
-    if (call_new) {
-      new(&str) std::string;
-    }
     deser >> str;
   }
 };

--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport.hpp
@@ -78,7 +78,7 @@ struct StringHelper<rosidl_typesupport_introspection_c__MessageMembers>
     return std::string(data.data);
   }
 
-  static void assign(cycdeser & deser, void * field, bool)
+  static void assign(cycdeser & deser, void * field)
   {
     std::string str;
     deser >> str;
@@ -131,8 +131,7 @@ protected:
 
 private:
   bool deserializeROSmessage(
-    cycdeser & deser, const MembersType * members, void * ros_message,
-    bool call_new);
+    cycdeser & deser, const MembersType * members, void * ros_message);
   bool printROSmessage(
     cycprint & deser, const MembersType * members);
 };

--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
@@ -248,8 +248,7 @@ template<typename T>
 void deserialize_field(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
   if (!member->is_array_) {
     deser >> *static_cast<T *>(field);
@@ -257,9 +256,6 @@ void deserialize_field(
     deser.deserializeA(static_cast<T *>(field), member->array_size_);
   } else {
     auto & vector = *reinterpret_cast<std::vector<T> *>(field);
-    if (call_new) {
-      new(&vector) std::vector<T>;
-    }
     deser >> vector;
   }
 }
@@ -268,30 +264,15 @@ template<>
 inline void deserialize_field<std::string>(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
   if (!member->is_array_) {
-    if (call_new) {
-      // Because std::string is a complex datatype, we need to make sure that
-      // the memory is initialized to something reasonable before eventually
-      // passing it as a reference.
-      new(field) std::string();
-    }
     deser >> *static_cast<std::string *>(field);
   } else if (member->array_size_ && !member->is_upper_bound_) {
     std::string * array = static_cast<std::string *>(field);
-    if (call_new) {
-      for (size_t i = 0; i < member->array_size_; ++i) {
-        new(&array[i]) std::string();
-      }
-    }
     deser.deserializeA(array, member->array_size_);
   } else {
     auto & vector = *reinterpret_cast<std::vector<std::string> *>(field);
-    if (call_new) {
-      new(&vector) std::vector<std::string>;
-    }
     deser >> vector;
   }
 }
@@ -300,10 +281,8 @@ template<>
 inline void deserialize_field<std::wstring>(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
-  (void)call_new;
   std::wstring wstr;
   if (!member->is_array_) {
     deser >> wstr;
@@ -330,10 +309,8 @@ template<typename T>
 void deserialize_field(
   const rosidl_typesupport_introspection_c__MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
-  (void)call_new;
   if (!member->is_array_) {
     deser >> *static_cast<T *>(field);
   } else if (member->array_size_ && !member->is_upper_bound_) {
@@ -351,13 +328,11 @@ template<>
 inline void deserialize_field<std::string>(
   const rosidl_typesupport_introspection_c__MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
-  (void)call_new;
   if (!member->is_array_) {
     using CStringHelper = StringHelper<rosidl_typesupport_introspection_c__MessageMembers>;
-    CStringHelper::assign(deser, field, call_new);
+    CStringHelper::assign(deser, field);
   } else {
     if (member->array_size_ && !member->is_upper_bound_) {
       auto deser_field = static_cast<rosidl_runtime_c__String *>(field);
@@ -398,10 +373,8 @@ template<>
 inline void deserialize_field<std::wstring>(
   const rosidl_typesupport_introspection_c__MessageMember * member,
   void * field,
-  cycdeser & deser,
-  bool call_new)
+  cycdeser & deser)
 {
-  (void)call_new;
   std::wstring wstr;
   if (!member->is_array_) {
     deser >> wstr;
@@ -429,7 +402,7 @@ inline void deserialize_field<std::wstring>(
 
 template<typename MembersType>
 bool TypeSupport<MembersType>::deserializeROSmessage(
-  cycdeser & deser, const MembersType * members, void * ros_message, bool call_new)
+  cycdeser & deser, const MembersType * members, void * ros_message)
 {
   assert(members);
   assert(ros_message);
@@ -439,57 +412,56 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
     void * field = static_cast<char *>(ros_message) + member->offset_;
     switch (member->type_id_) {
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BOOL:
-        deserialize_field<bool>(member, field, deser, call_new);
+        deserialize_field<bool>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        deserialize_field<uint8_t>(member, field, deser, call_new);
+        deserialize_field<uint8_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
-        deserialize_field<char>(member, field, deser, call_new);
+        deserialize_field<char>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT32:
-        deserialize_field<float>(member, field, deser, call_new);
+        deserialize_field<float>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_FLOAT64:
-        deserialize_field<double>(member, field, deser, call_new);
+        deserialize_field<double>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT16:
-        deserialize_field<int16_t>(member, field, deser, call_new);
+        deserialize_field<int16_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT16:
-        deserialize_field<uint16_t>(member, field, deser, call_new);
+        deserialize_field<uint16_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT32:
-        deserialize_field<int32_t>(member, field, deser, call_new);
+        deserialize_field<int32_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT32:
-        deserialize_field<uint32_t>(member, field, deser, call_new);
+        deserialize_field<uint32_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT64:
-        deserialize_field<int64_t>(member, field, deser, call_new);
+        deserialize_field<int64_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT64:
-        deserialize_field<uint64_t>(member, field, deser, call_new);
+        deserialize_field<uint64_t>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_STRING:
-        deserialize_field<std::string>(member, field, deser, call_new);
+        deserialize_field<std::string>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING:
-        deserialize_field<std::wstring>(member, field, deser, call_new);
+        deserialize_field<std::wstring>(member, field, deser);
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_MESSAGE:
         {
           auto sub_members = (const MembersType *)member->members_->data;
           if (!member->is_array_) {
-            deserializeROSmessage(deser, sub_members, field, call_new);
+            deserializeROSmessage(deser, sub_members, field);
           } else {
             void * subros_message = nullptr;
             size_t array_size = 0;
             size_t sub_members_size = sub_members->size_of_;
             size_t max_align = calculateMaxAlign(sub_members);
-            bool recall_new = call_new;
 
             if (member->array_size_ && !member->is_upper_bound_) {
               subros_message = field;
@@ -501,7 +473,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
             }
 
             for (size_t index = 0; index < array_size; ++index) {
-              deserializeROSmessage(deser, sub_members, subros_message, recall_new);
+              deserializeROSmessage(deser, sub_members, subros_message);
               subros_message = static_cast<char *>(subros_message) + sub_members_size;
               subros_message = align_ptr_(max_align, subros_message);
             }
@@ -628,7 +600,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
   }
 
   if (members_->member_count_ != 0) {
-    TypeSupport::deserializeROSmessage(deser, members_, ros_message, false);
+    TypeSupport::deserializeROSmessage(deser, members_, ros_message);
   } else {
     uint8_t dump = 0;
     deser >> dump;

--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
@@ -532,10 +532,9 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               subros_message = field;
               array_size = member->array_size_;
             } else {
-              array_size = get_submessage_array_deserialize(
-                member, deser, field, subros_message,
-                call_new, sub_members_size, max_align);
-              recall_new = true;
+              array_size = deser.deserialize_len(1);
+              member->resize_function(field, array_size);
+              subros_message = member->get_function(field, 0);
             }
 
             for (size_t index = 0; index < array_size; ++index) {

--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
@@ -127,6 +127,32 @@ align_int_(size_t __align, T __int) noexcept
   return (__int - 1u + __align) & ~(__align - 1);
 }
 
+inline
+void * get_subros_message(
+  const rosidl_typesupport_introspection_cpp::MessageMember * member,
+  void * field,
+  size_t index,
+  size_t,
+  bool)
+{
+  return member->get_function(field, index);
+}
+
+inline
+void * get_subros_message(
+  const rosidl_typesupport_introspection_c__MessageMember * member,
+  void * field,
+  size_t index,
+  size_t array_size,
+  bool is_upper_bound)
+{
+  if (array_size && !is_upper_bound) {
+    return member->get_function(&field, index);
+  }
+
+  return member->get_function(field, index);
+}
+
 template<typename T>
 void deserialize_field(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
@@ -359,7 +385,11 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               return false;
             }
             for (size_t index = 0; index < array_size; ++index) {
-              deserializeROSmessage(deser, sub_members, member->get_function(field, index));
+              deserializeROSmessage(
+                deser, sub_members,
+                get_subros_message(
+                  member, field, index, member->array_size_,
+                  member->is_upper_bound_));
             }
           }
         }

--- a/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/include/rmw_cyclonedds_cpp/TypeSupport_impl.hpp
@@ -427,43 +427,6 @@ inline void deserialize_field<std::wstring>(
   }
 }
 
-inline size_t get_submessage_array_deserialize(
-  const rosidl_typesupport_introspection_cpp::MessageMember * member,
-  cycdeser & deser,
-  void * field,
-  void * & subros_message,
-  bool call_new,
-  size_t sub_members_size,
-  size_t max_align)
-{
-  (void)member;
-  uint32_t vsize = deser.deserialize_len(1);
-  auto vector = reinterpret_cast<std::vector<unsigned char> *>(field);
-  if (call_new) {
-    new(vector) std::vector<unsigned char>;
-  }
-  vector->resize(vsize * align_int_(max_align, sub_members_size));
-  subros_message = reinterpret_cast<void *>(vector->data());
-  return vsize;
-}
-
-inline size_t get_submessage_array_deserialize(
-  const rosidl_typesupport_introspection_c__MessageMember * member,
-  cycdeser & deser,
-  void * field,
-  void * & subros_message,
-  bool,
-  size_t sub_members_size,
-  size_t)
-{
-  (void)member;
-  uint32_t vsize = deser.deserialize_len(1);
-  auto tmparray = static_cast<rosidl_runtime_c__void__Sequence *>(field);
-  rosidl_runtime_c__void__Sequence__init(tmparray, vsize, sub_members_size);
-  subros_message = reinterpret_cast<void *>(tmparray->data);
-  return vsize;
-}
-
 template<typename MembersType>
 bool TypeSupport<MembersType>::deserializeROSmessage(
   cycdeser & deser, const MembersType * members, void * ros_message, bool call_new)

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -550,21 +550,12 @@ static void handle_ParticipantEntitiesInfo(dds_entity_t reader, void * arg)
 {
   static_cast<void>(reader);
   rmw_context_impl_t * impl = static_cast<rmw_context_impl_t *>(arg);
+  ParticipantEntitiesInfo msg;
   bool taken;
-  do {
-    // TODO(iuhilnehc-ynos): Fix memory leak that string not deleted. (#224)
-    // This is a workaround to make sure calling destructor of ParticipantEntitiesInfo
-    // after calling rmw_take each time, otherwise, there will be a memory leak while
-    // deserializing a long enough buffer into a string member of NodeEntitiesInfo
-    // in ParticipantEntitiesInfo.
-    ParticipantEntitiesInfo msg;
-    if (rmw_take(impl->common.sub, &msg, &taken, nullptr) == RMW_RET_OK && taken) {
-      // locally published data is filtered because of the subscription QoS
-      impl->common.graph_cache.update_participant_entities(msg);
-    } else {
-      break;
-    }
-  } while (1);
+  while (rmw_take(impl->common.sub, &msg, &taken, nullptr) == RMW_RET_OK && taken) {
+    // locally published data is filtered because of the subscription QoS
+    impl->common.graph_cache.update_participant_entities(msg);
+  }
 }
 
 static void handle_DCPSParticipant(dds_entity_t reader, void * arg)


### PR DESCRIPTION
This PR is related to https://github.com/ros2/rmw_cyclonedds/issues/219

NOTE: I used multiple commits in a PR because it'll easy for me to revert some of them if they're unnecessary.

Signed-off-by: Chen.Lihui <lihui.chen@sony.com>