### PR TITLE
Suppress cppcheck unknownMacro

### DIFF
--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -9,3 +9,8 @@ repositories:
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
   ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo
+
+  ament/ament_lint:
+    type: git
+    url: https://github.com/ament/ament_lint.git
+    version: pull/268/merge

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,8 @@ jobs:
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
     - name: Acquire ROS dependencies
       uses: ros-tooling/setup-ros@master
+    - name: Set up git to see all pull requests
+      run: git config --global --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
     - name: Build and test ROS
       id: ros_ci
       uses: ros-tooling/action-ros-ci@0.0.19
@@ -37,4 +39,4 @@ jobs:
         target-ros2-distro: ${{matrix.rosdistro}}
         vcs-repo-file-url: >
           https://raw.githubusercontent.com/ros2/ros2/${{ matrix.repos_branch }}/ros2.repos
-          https://raw.githubusercontent.com/${{github.repository}}/${{github.sha}}/.github/resources/suppress_other_rmw.repos
+          https://raw.githubusercontent.com/${{github.repository}}/${{github.sha}}/.github/resources/local.repos


### PR DESCRIPTION
Fixes #220

Fast forward to https://github.com/ament/ament_lint/pull/268

This suppresses a defect in `ament_cppcheck` - namely that if a macro is missing at checking time, it fails loudly. This is compounded by fact that `ament_cppcheck` does not include all dependent headers, so macros are likely to be missing.

Signed-off-by: Dan Rose <dan@digilabs.io>
