### PR TITLE
Return RMW_RET_UNSUPPORTED in rmw_get_serialized_message_size

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1380,7 +1380,7 @@ extern "C" rmw_ret_t rmw_get_serialized_message_size(
   static_cast<void>(size);
 
   RMW_SET_ERROR_MSG("rmw_get_serialized_message_size: unimplemented");
-  return RMW_RET_ERROR;
+  return RMW_RET_UNSUPPORTED;
 }
 
 extern "C" rmw_ret_t rmw_serialize(


### PR DESCRIPTION
Return the right error code. Related with https://github.com/ros2/rmw/pull/281

Signed-off-by: ahcorde <ahcorde@gmail.com>