### PR TITLE
Handle potential divide by 0

### DIFF
--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -357,9 +357,10 @@ protected:
   {
     align %= max_align;
 
-    // Value of 0 implies it is not a primitive
+    // Value of 0 implies it is not a primitive, which should not happen and is checked elsewhere
     const size_t cdr_alignof = get_cdr_alignof_primitive(v.type_kind());
-    if (cdr_alignof == 0 || align % cdr_alignof != 0) {
+    assert(0 != cdr_alignof);
+    if (align % cdr_alignof != 0) {
       return false;
     }
     return v.sizeof_type() == get_cdr_size_of_primitive(v.type_kind());

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -357,7 +357,9 @@ protected:
   {
     align %= max_align;
 
-    if (align % get_cdr_alignof_primitive(v.type_kind()) != 0) {
+    // Value of 0 implies it is not a primitive
+    const size_t cdr_alignof = get_cdr_alignof_primitive(v.type_kind());
+    if (cdr_alignof == 0 || align % cdr_alignof != 0) {
       return false;
     }
     return v.sizeof_type() == get_cdr_size_of_primitive(v.type_kind());


### PR DESCRIPTION
Since `get_cdr_alignof_primitive` can potentially return 0 if `v.type_kind()` is not a primitive type, clang static analysis flags this `if` branch as having potentially undefined behavior.

I wasn't entirely sure what to do here. I could use an `assert(cdr_alignof != 0)` since this is situation is not supposed to occur, but returning false also seemed like a decent solution.

Signed-off-by: Stephen Brawner <brawner@gmail.com>