### PR TITLE
Use type erased unique_ptr for type support classes to fix memory leaks

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -80,6 +80,7 @@
 #include "serdes.hpp"
 #include "serdata.hpp"
 #include "demangle.hpp"
+#include "unique_void.hpp"
 
 using namespace std::literals::chrono_literals;
 
@@ -3803,7 +3804,8 @@ static rmw_ret_t rmw_init_cs(
   auto pub = std::make_unique<CddsPublisher>();
   auto sub = std::make_unique<CddsSubscription>();
   std::string subtopic_name, pubtopic_name;
-  void * pub_type_support, * sub_type_support;
+  unique_void_ptr_t pub_type_support{make_null_unique_void()};
+  unique_void_ptr_t sub_type_support{make_null_unique_void()};
 
   std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> pub_msg_ts, sub_msg_ts;
 
@@ -3842,7 +3844,7 @@ static rmw_ret_t rmw_init_cs(
   struct sertopic_rmw * pub_st, * sub_st;
 
   pub_st = create_sertopic(
-    pubtopic_name.c_str(), type_support->typesupport_identifier, pub_type_support, true,
+    pubtopic_name.c_str(), type_support->typesupport_identifier, std::move(pub_type_support), true,
     std::move(pub_msg_ts));
   struct ddsi_sertopic * pub_stact;
   pubtopic = create_topic(node->context->impl->ppant, pub_st, &pub_stact);
@@ -3852,7 +3854,7 @@ static rmw_ret_t rmw_init_cs(
   }
 
   sub_st = create_sertopic(
-    subtopic_name.c_str(), type_support->typesupport_identifier, sub_type_support, true,
+    subtopic_name.c_str(), type_support->typesupport_identifier, std::move(sub_type_support), true,
     std::move(sub_msg_ts));
   subtopic = create_topic(node->context->impl->ppant, sub_st);
   if (subtopic < 0) {

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -73,55 +73,55 @@ static bool using_introspection_cpp_typesupport(const char * typesupport_identif
   return typesupport_identifier == rosidl_typesupport_introspection_cpp::typesupport_identifier;
 }
 
-void * create_message_type_support(
+unique_void_ptr_t create_message_type_support(
   const void * untyped_members,
   const char * typesupport_identifier)
 {
   if (using_introspection_c_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(untyped_members);
-    return new MessageTypeSupport_c(members);
+    return make_unique_void(new MessageTypeSupport_c(members));
   } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(untyped_members);
-    return new MessageTypeSupport_cpp(members);
+    return make_unique_void(new MessageTypeSupport_cpp(members));
   }
   RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
+  return make_null_unique_void();
 }
 
-void * create_request_type_support(
+unique_void_ptr_t create_request_type_support(
   const void * untyped_members,
   const char * typesupport_identifier)
 {
   if (using_introspection_c_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(untyped_members);
-    return new RequestTypeSupport_c(members);
+    return make_unique_void(new RequestTypeSupport_c(members));
   } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(untyped_members);
-    return new RequestTypeSupport_cpp(members);
+    return make_unique_void(new RequestTypeSupport_cpp(members));
   }
   RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
+  return make_null_unique_void();
 }
 
-void * create_response_type_support(
+unique_void_ptr_t create_response_type_support(
   const void * untyped_members,
   const char * typesupport_identifier)
 {
   if (using_introspection_c_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_c__ServiceMembers *>(untyped_members);
-    return new ResponseTypeSupport_c(members);
+    return make_unique_void(new ResponseTypeSupport_c(members));
   } else if (using_introspection_cpp_typesupport(typesupport_identifier)) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_cpp::ServiceMembers *>(untyped_members);
-    return new ResponseTypeSupport_cpp(members);
+    return make_unique_void(new ResponseTypeSupport_cpp(members));
   }
   RMW_SET_ERROR_MSG("Unknown typesupport identifier");
-  return nullptr;
+  return make_null_unique_void();
 }
 
 static uint32_t serdata_rmw_size(const struct ddsi_serdata * dcmn)
@@ -283,11 +283,11 @@ static bool serdata_rmw_to_sample(
       cycdeser sd(d->data(), d->size());
       if (using_introspection_c_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_.get());
         return typed_typesupport->deserializeROSmessage(sd, sample);
       } else if (using_introspection_cpp_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_.get());
         return typed_typesupport->deserializeROSmessage(sd, sample);
       }
     } else {
@@ -299,11 +299,11 @@ static bool serdata_rmw_to_sample(
       cycdeser sd(d->data(), d->size());
       if (using_introspection_c_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_.get());
         return typed_typesupport->deserializeROSmessage(sd, wrap->data, prefix);
       } else if (using_introspection_cpp_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_.get());
         return typed_typesupport->deserializeROSmessage(sd, wrap->data, prefix);
       }
     }
@@ -354,11 +354,11 @@ static size_t serdata_rmw_print(
       cycprint sd(buf, bufsize, d->data(), d->size());
       if (using_introspection_c_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_.get());
         return typed_typesupport->printROSmessage(sd);
       } else if (using_introspection_cpp_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_.get());
         return typed_typesupport->printROSmessage(sd);
       }
     } else {
@@ -372,11 +372,11 @@ static size_t serdata_rmw_print(
       cycprint sd(buf, bufsize, d->data(), d->size());
       if (using_introspection_c_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_c *>(topic->type_support.type_support_.get());
         return typed_typesupport->printROSmessage(sd, prefix);
       } else if (using_introspection_cpp_typesupport(topic->type_support.typesupport_identifier_)) {
         auto typed_typesupport =
-          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_);
+          static_cast<MessageTypeSupport_cpp *>(topic->type_support.type_support_.get());
         return typed_typesupport->printROSmessage(sd, prefix);
       }
     }
@@ -561,19 +561,19 @@ static std::string get_type_name(const char * type_support_identifier, void * ty
 
 struct sertopic_rmw * create_sertopic(
   const char * topicname, const char * type_support_identifier,
-  void * type_support, bool is_request_header,
+  unique_void_ptr_t type_support, bool is_request_header,
   std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type)
 {
   struct sertopic_rmw * st = new struct sertopic_rmw;
 #if DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY
-  std::string type_name = get_type_name(type_support_identifier, type_support);
+  std::string type_name = get_type_name(type_support_identifier, type_support.get());
   ddsi_sertopic_init(
     static_cast<struct ddsi_sertopic *>(st), topicname,
     type_name.c_str(), &sertopic_rmw_ops, &serdata_rmw_ops, true);
 #else
   memset(st, 0, sizeof(struct ddsi_sertopic));
   st->cpp_name = std::string(topicname);
-  st->cpp_type_name = get_type_name(type_support_identifier, type_support);
+  st->cpp_type_name = get_type_name(type_support_identifier, type_support.get());
   st->cpp_name_type_name = st->cpp_name + std::string(";") + std::string(st->cpp_type_name);
   st->ops = &sertopic_rmw_ops;
   st->serdata_ops = &serdata_rmw_ops;
@@ -585,7 +585,7 @@ struct sertopic_rmw * create_sertopic(
   ddsrt_atomic_st32(&st->refc, 1);
 #endif
   st->type_support.typesupport_identifier_ = type_support_identifier;
-  st->type_support.type_support_ = type_support;
+  st->type_support.type_support_ = std::move(type_support);
   st->is_request_header = is_request_header;
   st->cdr_writer = rmw_cyclonedds_cpp::make_cdr_writer(std::move(message_type));
   return st;

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -435,14 +435,6 @@ static void sertopic_rmw_free(struct ddsi_sertopic * tpcmn)
 #if DDSI_SERTOPIC_HAS_TOPICKIND_NO_KEY
   ddsi_sertopic_fini(tpcmn);
 #endif
-  if (tp->type_support.type_support_) {
-    if (using_introspection_c_typesupport(tp->type_support.typesupport_identifier_)) {
-      delete static_cast<TypeSupport_c *>(tp->type_support.type_support_);
-    } else if (using_introspection_cpp_typesupport(tp->type_support.typesupport_identifier_)) {
-      delete static_cast<TypeSupport_cpp *>(tp->type_support.type_support_);
-    }
-    tp->type_support.type_support_ = NULL;
-  }
 
   delete tp;
 }

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -21,6 +21,7 @@
 #include "bytewise.hpp"
 #include "dds/ddsi/ddsi_serdata.h"
 #include "dds/ddsi/ddsi_sertopic.h"
+#include "unique_void.hpp"
 
 namespace rmw_cyclonedds_cpp
 {
@@ -29,7 +30,7 @@ class BaseCDRWriter;
 
 struct CddsTypeSupport
 {
-  void * type_support_;
+  unique_void_ptr_t type_support_{make_null_unique_void()};
   const char * typesupport_identifier_;
 };
 
@@ -72,19 +73,19 @@ typedef struct cdds_request_wrapper
   void * data;
 } cdds_request_wrapper_t;
 
-void * create_message_type_support(
+unique_void_ptr_t create_message_type_support(
   const void * untyped_members,
   const char * typesupport_identifier);
-void * create_request_type_support(
+unique_void_ptr_t create_request_type_support(
   const void * untyped_members,
   const char * typesupport_identifier);
-void * create_response_type_support(
+unique_void_ptr_t create_response_type_support(
   const void * untyped_members,
   const char * typesupport_identifier);
 
 struct sertopic_rmw * create_sertopic(
   const char * topicname, const char * type_support_identifier,
-  void * type_support, bool is_request_header,
+  unique_void_ptr_t type_support, bool is_request_header,
   std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type_support);
 
 struct ddsi_serdata * serdata_rmw_from_serialized_message(

--- a/rmw_cyclonedds_cpp/src/unique_void.hpp
+++ b/rmw_cyclonedds_cpp/src/unique_void.hpp
@@ -1,0 +1,38 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UNIQUE_VOID_HPP_
+#define UNIQUE_VOID_HPP_
+
+// https://stackoverflow.com/a/39288979
+
+using unique_void_ptr_t = std::unique_ptr<void, void(*)(void const*)>;
+
+template<typename T>
+unique_void_ptr_t
+make_unique_void(T * ptr)
+{
+    return unique_void_ptr_t(ptr, [](void const * data) {
+         auto p = static_cast<T const *>(data);
+         delete p;
+    });
+}
+
+inline
+unique_void_ptr_t
+make_null_unique_void()
+{
+    return unique_void_ptr_t(nullptr, [](void const *) {});
+}
+#endif  // UNIQUE_VOID_HPP_


### PR DESCRIPTION
This reduces the number of leaks reported in #269. It uses a type-erased `unique_ptr<void,...>` instead of a `void *` for the type_support classes to make sure they get deleted. The amount of leaked data in the example in #269 reduces from 2517 bytes in 57 allocations without this PR to 900 bytes leaked in 21 allocations with this PR.

Note, I tested this on the `foxy` branch, but I've opened the PR on `master` because it cherry-picked cleanly. Assuming it's merged, it should be backported to Foxy.