### PR TITLE
Handle typesupport errors on fetch.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1568,13 +1568,22 @@ static const rosidl_message_type_support_t * get_typesupport(
   {
     return ts;
   } else {
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string();
+    rcutils_reset_error();
     if ((ts =
       get_message_typesupport_handle(
         type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier)) != nullptr)
     {
       return ts;
     } else {
-      RMW_SET_ERROR_MSG("type support not from this implementation");
+      rcutils_error_string_t error_string = rcutils_get_error_string();
+      rcutils_reset_error();
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Type support not from this implementation. Got:\n"
+        "    %s\n"
+        "    %s\n"
+        "while fetching it",
+        prev_error_string.str, error_string.str);
       return nullptr;
     }
   }
@@ -3728,13 +3737,22 @@ static const rosidl_service_type_support_t * get_service_typesupport(
   {
     return ts;
   } else {
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string();
+    rcutils_reset_error();
     if ((ts =
       get_service_typesupport_handle(
         type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier)) != nullptr)
     {
       return ts;
     } else {
-      RMW_SET_ERROR_MSG("service type support not from this implementation");
+      rcutils_error_string_t error_string = rcutils_get_error_string();
+      rcutils_reset_error();
+      RMW_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Service type support not from this implementation. Got:\n"
+        "    %s\n"
+        "    %s\n"
+        "while fetching it",
+        prev_error_string.str, error_string.str);
       return nullptr;
     }
   }


### PR DESCRIPTION
Follow-up after https://github.com/ros2/rosidl_typesupport/pull/99. Missing error handling code caused test failures in downstream packages (e.g. https://ci.ros2.org/view/nightly/job/nightly_linux-aarch64_release/1415/). This patch addresses them.


Full CI (just in case):

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13273)](http://ci.ros2.org/job/ci_linux/13273/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8205)](http://ci.ros2.org/job/ci_linux-aarch64/8205/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10993)](http://ci.ros2.org/job/ci_osx/10993/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13304)](http://ci.ros2.org/job/ci_windows/13304/)
