### PR TITLE
Reset the error on failing to find the C typesupport

### DIFF
--- a/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
@@ -18,6 +18,9 @@
 #include <utility>
 #include <vector>
 
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
+
 namespace rmw_cyclonedds_cpp
 {
 class ROSIDLC_StructValueType : public StructValueType
@@ -68,12 +71,12 @@ public:
 
 std::unique_ptr<StructValueType> make_message_value_type(const rosidl_message_type_support_t * mts)
 {
-  if (auto ts_c = mts->func(mts, TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::get_identifier())) {
+  if (auto ts_c = get_message_typesupport_handle(mts, TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::get_identifier())) {
     auto members = static_cast<const MetaMessage<TypeGenerator::ROSIDL_C> *>(ts_c->data);
     return std::make_unique<ROSIDLC_StructValueType>(members);
   }
   if (auto ts_cpp =
-    mts->func(mts, TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
+    get_message_typesupport_handle(mts, TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
   {
     auto members = static_cast<const MetaMessage<TypeGenerator::ROSIDL_Cpp> *>(ts_cpp->data);
     return std::make_unique<ROSIDLCPP_StructValueType>(members);
@@ -86,7 +89,7 @@ std::pair<std::unique_ptr<StructValueType>, std::unique_ptr<StructValueType>>
 make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
 {
   if (auto tsc =
-    svc_ts->func(svc_ts, TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::get_identifier()))
+    get_service_typesupport_handle(svc_ts, TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::get_identifier()))
   {
     auto typed =
       static_cast<const TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::MetaService *>(tsc->data);
@@ -97,7 +100,7 @@ make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
   }
 
   if (auto tscpp =
-    svc_ts->func(svc_ts, TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
+    get_service_typesupport_handle(svc_ts, TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
   {
     auto typed =
       static_cast<const TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::MetaService *>(tscpp->data);


### PR DESCRIPTION
The individual commits have more information, but essentially make sure to reset the error in between calls to probing for typesupport.  This should fix the bulk of the test failures we are seeing in https://github.com/ros2/rmw/pull/293 .

@eboasson Note that this is different than what we had discussed earlier.  After talking to some more people, changing the contract of [get_typesupport_handle_function](https://github.com/ros2/rosidl_typesupport/blob/64dd1be918b759f0a2d0c731ebe38ccbbe4601b4/rosidl_typesupport_cpp/src/type_support_dispatch.hpp#L37) is a little more dangerous than we want to attempt right now .  So this is the more targeted, if less ideal, solution.  I'll likely still open an issue to follow-up and change that contract, since the current contract seems a bit ugly.

CI for this change is in https://github.com/ros2/rmw/pull/293 .