### PR TITLE
Fix use-after-free in error handling bug

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1929,7 +1929,6 @@ fail_writer:
   dds_delete_qos(qos);
 fail_qos:
   dds_delete(topic);
-  ddsi_sertype_unref(stact);
 fail_topic:
   delete pub;
   return nullptr;


### PR DESCRIPTION
The reference to the sertype is not counted and shouldn't be released.
At this point, and in this test anyway, the memory has been freed just
before (by `dds_delete(topic)`) and this probably explains why it hasn't
caused any breakage before.  The assert that failed now is new in
Cyclone.

There has been an ancient interface for creating custom types that did
require it and that was used by `rmw_cyclonedds_cpp` in the past.  The
rewrite of the RMW layer to use one DDS participant per context
(commit 8a1d3fc092d1d4841c9f5c39e7da0e3b26886add) also dropped support
for that ancient interface.  Instead of removing the #if/unref/#endif,
that commit removed the #if/#endif but left the unref call in place.

Signed-off-by: Erik Boasson <eb@ilities.com>

This fixes #277 