### PR TITLE
Fix dds_take buffer argument in rmw_take_sequence

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2656,8 +2656,12 @@ static rmw_ret_t rmw_take_seq(
   RET_NULL(sub);
 
   std::vector<dds_sample_info_t> infos(count);
+  std::vector<void *> ptrs(count);
   auto maxsamples = static_cast<uint32_t>(count);
-  auto ret = dds_take(sub->enth, message_sequence->data, infos.data(), count, maxsamples);
+  for (size_t i = 0; i < count; i++) {
+    ptrs[i] = &message_sequence->data[i];
+  }
+  auto ret = dds_take(sub->enth, ptrs.data(), infos.data(), count, maxsamples);
 
   // Returning 0 should not be an error, as it just indicates that no messages were available.
   if (ret < 0) {


### PR DESCRIPTION
This fixes the crash in #279 

It doesn't address the other observations made there, such as the need for improving Cyclone DDS' read/take interface.

I also note that there are *no tests* in ROS 2 for the "take sequence" operation where it actually returns some data. I've hacked it into the rmw implementation subscription tests to check my hypothesis on the crash and the behaviour of my fix, but that hack isn't suitable for public viewing. Perhaps it would make sense to consider adding proper tests in a proper location.