### PR TITLE
Fix github workflows

### DIFF
--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -9,8 +9,3 @@ repositories:
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
   ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo
-
-  ament/ament_lint:
-    type: git
-    url: https://github.com/ament/ament_lint.git
-    version: pull/268/merge

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
       run: git config --global --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
     - name: Build and test ROS
       id: ros_ci
-      uses: ros-tooling/action-ros-ci@0.0.19
+      uses: ros-tooling/action-ros-ci@v0.1
       with:
         package-name: >
           rmw_cyclonedds_cpp


### PR DESCRIPTION
Workflows started to fail after https://github.com/ament/ament_lint/pull/268 was merged, e.g.: https://github.com/ros2/rmw_cyclonedds/pull/288.

This should fix it :crossed_fingers: 