### PR TITLE
Remove ubuntu-18.04 job from CI config matrix and ignore rmw_connextdds

### DIFF
--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -5,7 +5,6 @@ definitions:
 
 repositories:
   ros2/rosidl_typesupport_connext/COLCON_IGNORE: *empty_repo
-  ros2/rmw_connext/COLCON_IGNORE: *empty_repo
   ros2/rmw_connextdds/COLCON_IGNORE: *empty_repo
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo

--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -4,7 +4,6 @@ definitions:
     url: data:application/zip;base64,UEsFBgAAAAAAAAAAAAAAAAAAAAAAAA==
 
 repositories:
-  ros2/rosidl_typesupport_connext/COLCON_IGNORE: *empty_repo
   ros2/rmw_connextdds/COLCON_IGNORE: *empty_repo
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo

--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -6,6 +6,7 @@ definitions:
 repositories:
   ros2/rosidl_typesupport_connext/COLCON_IGNORE: *empty_repo
   ros2/rmw_connext/COLCON_IGNORE: *empty_repo
+  ros2/rmw_connextdds/COLCON_IGNORE: *empty_repo
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
   ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
       run: git config --global --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
     - name: Build and test ROS
       id: ros_ci
-      uses: ros-tooling/action-ros-ci@v0.1
+      uses: ros-tooling/action-ros-ci@v0.2
       with:
         package-name: >
           rmw_cyclonedds_cpp

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,6 +27,9 @@ jobs:
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
     - name: Acquire ROS dependencies
       uses: ros-tooling/setup-ros@master
+      with:
+        # Install to avoid getting stuck on the license agreement prompt
+        install-connext: true
     - name: Set up git to see all pull requests
       run: git config --global --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
     - name: Build and test ROS

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
           rosdistro: [rolling]
-          os: [ubuntu-18.04, ubuntu-20.04, macOS-latest, windows-latest]
+          os: [ubuntu-20.04, macOS-latest, windows-latest]
           include:
           - rosdistro: rolling
             repos_branch: master


### PR DESCRIPTION
There's no real reason to have it. It's not officially supported for Rolling.

Also, ignore `rmw_connextdds` in CI (just like `rmw_connext`). Note that if you want to keep the `ubuntu-18.04` job, this might fix it.

Finally, I bumped `action-ros-ci` to `v0.2`. This fixes the issue for Windows, although there seems to be another issue. Still an improvement though!