### PR TITLE
Handle allocation errors during message deserialization

### DIFF
--- a/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
@@ -75,6 +75,34 @@ align_int_(size_t __align, T __int) noexcept
   return (__int - 1u + __align) & ~(__align - 1);
 }
 
+template<typename MembersType>
+void resize_field(
+  const MembersType * member,
+  void * field,
+  size_t size)
+{
+  if (!member->resize_function) {
+    throw std::runtime_error("unexpected error: resize function is null");
+  }
+
+  member->resize_function(field, size);
+}
+
+template<>
+inline void resize_field<rosidl_typesupport_introspection_c__MessageMember>(
+  const rosidl_typesupport_introspection_c__MessageMember * member,
+  void * field,
+  size_t size)
+{
+  if (!member->resize_function) {
+    throw std::runtime_error("unexpected error: resize function is null");
+  }
+
+  if (!member->resize_function(field, size)) {
+    throw std::runtime_error("unable to resize field");
+  }
+}
+
 template<typename T>
 void deserialize_field(
   const rosidl_typesupport_introspection_cpp::MessageMember * member,
@@ -125,7 +153,7 @@ inline void deserialize_field<std::wstring>(
       size = static_cast<uint32_t>(member->array_size_);
     } else {
       deser >> size;
-      member->resize_function(field, size);
+      resize_field(member, field, size);
     }
     for (size_t i = 0; i < size; ++i) {
       void * element = member->get_function(field, i);
@@ -150,7 +178,9 @@ void deserialize_field(
     auto & data = *reinterpret_cast<typename GenericCSequence<T>::type *>(field);
     int32_t dsize = 0;
     deser >> dsize;
-    GenericCSequence<T>::init(&data, dsize);
+    if (!GenericCSequence<T>::init(&data, dsize)) {
+      throw std::runtime_error("unable initialize generic sequence");
+    }
     deser.deserializeA(reinterpret_cast<T *>(data.data), dsize);
   }
 }
@@ -295,11 +325,7 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
               array_size = member->array_size_;
             } else {
               array_size = deser.deserialize_len(1);
-              if (!member->resize_function) {
-                RMW_SET_ERROR_MSG("unexpected error: resize function is null");
-                return false;
-              }
-              member->resize_function(field, array_size);
+              resize_field(member, field, array_size);
             }
 
             if (array_size != 0 && !member->get_function) {


### PR DESCRIPTION
Precisely what the title says. This should address the test failures in nightlies (e.g. [here](https://ci.ros2.org/view/nightly/job/nightly_linux_debug/lastCompletedBuild/testReport/(root)/rcl_action/test_action_communication__rmw_cyclonedds_cpp_gtest_missing_result/)).

CI up to `rmw_cyclonedds_cpp` and `rcl_action`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14579)](http://ci.ros2.org/job/ci_linux/14579/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9334)](http://ci.ros2.org/job/ci_linux-aarch64/9334/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12243)](http://ci.ros2.org/job/ci_osx/12243/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14706)](http://ci.ros2.org/job/ci_windows/14706/)

This isn't a great fix though. I found error handling to be somewhat inconsistent in these source files. Sometimes exceptions are thrown, sometimes an `rmw` error is set and a falsy boolean is returned, sometimes errors are ignored. I couldn't find a pattern.