### PR TITLE
Add publishing instrumentation using tracetools

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -29,6 +29,7 @@ find_package(ament_cmake_ros REQUIRED)
 
 find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(tracetools REQUIRED)
 
 #find_package(cyclonedds_cmake_module REQUIRED)
 find_package(CycloneDDS QUIET CONFIG)
@@ -77,6 +78,7 @@ ament_target_dependencies(rmw_cyclonedds_cpp
   "rmw"
   "rmw_dds_common"
   "rosidl_runtime_c"
+  "tracetools"
 )
 
 configure_rmw_library(rmw_cyclonedds_cpp)

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -18,6 +18,7 @@
   <depend>rosidl_runtime_c</depend>
   <depend>rosidl_typesupport_introspection_c</depend>
   <depend>rosidl_typesupport_introspection_cpp</depend>
+  <depend>tracetools</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -75,6 +75,8 @@
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
+#include "tracetools/tracetools.h"
+
 #include "namespace_prefix.hpp"
 
 #include "dds/dds.h"
@@ -1543,6 +1545,7 @@ extern "C" rmw_ret_t rmw_publish(
     return RMW_RET_INVALID_ARGUMENT);
   auto pub = static_cast<CddsPublisher *>(publisher->data);
   assert(pub);
+  TRACEPOINT(rmw_publish, static_cast<const void *>(publisher), ros_message);
   if (dds_write(pub->enth, ros_message) >= 0) {
     return RMW_RET_OK;
   } else {


### PR DESCRIPTION
Requires https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/249

This adds instrumentation for the most common `rmw_publish*` function.

This goes along instrumentation for `rclcpp` (https://github.com/ros2/rclcpp/pull/1600) and `rcl` (https://github.com/ros2/rcl/pull/905). The goal is to track messages from the user code down to DDS and the network.

action-ros-ci-repos-override: https://gist.githubusercontent.com/christophebedard/e8b4c9567a7261ed955c67d7de6cd1ff/raw/d7deda7d7294b21d27a08dfbdcb19fdc1192cb76/ros2.repos
action-ros-ci-repos-override: https://raw.githubusercontent.com/ros2/rmw_cyclonedds/master/.github/resources/local.repos

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>