### PR TITLE
Pass the CRL down to CycloneDDS if it exists.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -872,6 +872,10 @@ rmw_ret_t configure_qos_for_security(
   dds_qset_prop(qos, "dds.sec.access.library.init", "init_access_control");
   dds_qset_prop(qos, "dds.sec.access.library.finalize", "finalize_access_control");
 
+  if (security_files.count("CRL") > 0) {
+    dds_qset_prop(qos, "org.eclipse.cyclonedds.sec.auth.crl", security_files["CRL"].c_str());
+  }
+
   return RMW_RET_OK;
 #else
   (void) qos;


### PR DESCRIPTION
If the rmw_dds_common layer tells us that the CRL exists,
set the appropriate property so CycloneDDS will honor it.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this can be merged at any time, but will have no effect until https://github.com/ros2/rmw_dds_common/pull/52 is merged.