### PR TITLE
add -latomic in CMakelist.txt

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -70,8 +70,18 @@ target_include_directories(rmw_cyclonedds_cpp PUBLIC
 
 target_link_libraries(rmw_cyclonedds_cpp
   CycloneDDS::ddsc
-  -latomic
 )
+if (CMAKE_GENERATOR_PLATFORM)
+  set (TARGET_ARCH "${CMAKE_GENERATOR_PLATFORM}")
+else ()
+  set (TARGET_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+endif ()
+
+if (CMAKE_COMPILER_IS_GNUCXX AND TARGET_ARCH MATCHES "^(riscv|RISCV)64$")
+  # using GCC, libatomic is not automatically linked for RISC-V
+  target_link_libraries(rmw_cyclonedds_cpp -latomic)
+endif ()
+
 
 ament_target_dependencies(rmw_cyclonedds_cpp
   "rcutils"

--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -70,9 +70,6 @@ target_include_directories(rmw_cyclonedds_cpp PUBLIC
 
 target_link_libraries(rmw_cyclonedds_cpp
   CycloneDDS::ddsc
-)
-
-target_link_libraries(rmw_cyclonedds_cpp
   -latomic
 )
 

--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -72,6 +72,10 @@ target_link_libraries(rmw_cyclonedds_cpp
   CycloneDDS::ddsc
 )
 
+target_link_libraries(rmw_cyclonedds_cpp
+  -latomic
+)
+
 ament_target_dependencies(rmw_cyclonedds_cpp
   "rcutils"
   "rcpputils"


### PR DESCRIPTION
In order to compile the RISC-V architecture, the atomic library has to been linked explicitly.