### PR TITLE
Free with the same allocator in rmw_destroy_node

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1369,10 +1369,9 @@ extern "C" rmw_ret_t rmw_destroy_node(rmw_node_t * node)
   }
 
   rmw_context_t * context = node->context;
-  rcutils_allocator_t allocator = context->options.allocator;
-  allocator.deallocate(const_cast<char *>(node->name), allocator.state);
-  allocator.deallocate(const_cast<char *>(node->namespace_), allocator.state);
-  allocator.deallocate(node, allocator.state);
+  rmw_free(const_cast<char *>(node->name));
+  rmw_free(const_cast<char *>(node->namespace_));
+  rmw_node_free(const_cast<rmw_node_t *>(node));
   delete node_impl;
   context->impl->fini();
   return result_ret;


### PR DESCRIPTION
Since rmw_allocate() was used to allocate memory, we should use rmw_free() to cleanup.
Otherwise, if the user provided a custom allocator to the context we will be calling deallocate with the wrong allocator.

---

I hit a runtime error due to this bug while I was using a custom allocator.
There may be other places in the code where we're making a similar mistake. I haven't audited the rest of the code, but I'll make sure to fix similar instances if I come across them.

This should be considered for backport to Galactic and Foxy!