### PR TITLE
Bump QDs to QL2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ If building ROS 2 from source ([ros2.repos](https://github.com/ros2/ros2/blob/ma
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./rmw_cyclonedds_cpp/QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](./rmw_cyclonedds_cpp/QUALITY_DECLARATION.md) for more details.

--- a/rmw_cyclonedds_cpp/QUALITY_DECLARATION.md
+++ b/rmw_cyclonedds_cpp/QUALITY_DECLARATION.md
@@ -137,8 +137,8 @@ Results of the nightly linter tests can be found [here](https://ci.ros2.org/view
 * `rmw_dds_common`: [QUALITY DECLARATION](https://github.com/ros2/rmw_dds_common/blob/master/rmw_dds_common/QUALITY_DECLARATION.md)
 * `rosidl_runtime_c`: [QUALITY DECLARATION](https://github.com/ros2/rosidl/blob/master/rosidl_runtime_c/QUALITY_DECLARATION.md)
 * `rosidl_runtime_cpp`: [QUALITY DECLARATION](https://github.com/ros2/rosidl/blob/master/rosidl_runtime_cpp/QUALITY_DECLARATION.md)
-* `rosidl_typesupport_introspection_c`: no quality declaration
-* `rosidl_typesupport_introspection_cpp`: no quality declaration
+* `rosidl_typesupport_introspection_c`: [QUALITY DECLARATION](https://github.com/ros2/rosidl/blob/master/rosidl_typesupport_introspection_c/QUALITY_DECLARATION.md)
+* `rosidl_typesupport_introspection_cpp`: [QUALITY DECLARATION](https://github.com/ros2/rosidl/blob/master/rosidl_typesupport_introspection_cpp/QUALITY_DECLARATION.md)
 * `tracetools`: [QUALITY DECLARATION](https://gitlab.com/ros-tracing/ros2_tracing/-/blob/master/tracetools/QUALITY_DECLARATION.md)
 
 It has several "buildtool" dependencies, which do not affect the resulting quality of the package, because they do not contribute to the public library API.
@@ -201,7 +201,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |4.v.a| Code style enforcement (linters)| ✓ |
 |4.v.b| Use of static analysis tools | ✓ |
 |5| **Dependencies** | --- |
-|5.i| Must not have ROS lower level dependencies | x |
+|5.i| Must not have ROS lower level dependencies | ✓ |
 |5.ii| Optional ROS lower level dependencies| ✓ |
 |5.iii| Justifies quality use of non-ROS dependencies | ✓ |
 |6| **Platform support** | --- |

--- a/rmw_cyclonedds_cpp/QUALITY_DECLARATION.md
+++ b/rmw_cyclonedds_cpp/QUALITY_DECLARATION.md
@@ -2,9 +2,9 @@ This document is a declaration of software quality for the `rmw_cyclonedds_cpp` 
 
 # `rmw_cyclonedds_cpp` Quality Declaration
 
-The package `rmw_cyclonedds_cpp` claims to be in the **Quality Level 3** category.
+The package `rmw_cyclonedds_cpp` claims to be in the **Quality Level 2** category.
 
-Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 4 in REP-2004](https://www.ros.org/reps/rep-2004.html).
+Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 2 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
 ## Version Policy [1]
 
@@ -173,7 +173,7 @@ The chart below compares the requirements in the REP-2004 with the current state
 |--|--|--|
 |1| **Version policy** |---|
 |1.i|Version Policy available | ✓ |
-|1.ii|Stable version | x |
+|1.ii|Stable version | ✓ |
 |1.iii|Declared public API| ✓ |
 |1.iv|API stability policy| ✓ |
 |1.v|ABI stability policy| ✓ |


### PR DESCRIPTION
And therefore requirement 5.i is fulfilled.

I also noticed that 1.ii can also be marked as done, so this results in a bump to QL2. This can't be bumped to QL1 because [`rmw_dds_common`'s QL1 requires a QL1 middleware](https://github.com/ros2/rmw_dds_common/blob/master/rmw_dds_common/QUALITY_DECLARATION.md#rmw_dds_common-quality-declaration). If `cyclonedds` is bumped from QL2 to QL1, then I think `rmw_cyclonedds_cpp` can also be bumped to QL1.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>