### PR TITLE
Update CI workflow

### DIFF
--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -9,8 +9,3 @@ repositories:
 
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
   ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo
-
-  ament/ament_lint:
-    type: git
-    url: https://github.com/ament/ament_lint.git
-    version: pull/268/merge

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
           rosdistro: [foxy]
-          os: [ubuntu-20.04, windows-2019]
+          os: [ubuntu-20.04] # , windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Windows'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
           rosdistro: [foxy]
-          os: [ubuntu-20.04, windows-latest]
+          os: [ubuntu-20.04, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Windows'
@@ -18,6 +18,9 @@ jobs:
     - if: runner.os == 'Linux'
       # azure ubuntu repo can be flaky so add an alternate source
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
+    - if: runner.os == 'Windows'
+      name: Pin pip
+      run: python -m pip install -U pip==21.3.1
     - name: Acquire ROS dependencies
       uses: ros-tooling/setup-ros@v0.2
       with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
       fail-fast: false
       matrix:
           rosdistro: [foxy]
-          os: [ubuntu-18.04, macOS-latest, windows-latest]
+          os: [ubuntu-20.04, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - if: runner.os == 'Windows'
@@ -19,11 +19,14 @@ jobs:
       # azure ubuntu repo can be flaky so add an alternate source
       run: sed -e 's/azure.archive.ubuntu.com/us.archive.ubuntu.com/g' -e t -e d /etc/apt/sources.list | sudo tee /etc/apt/sources.list.d/nonazure.list
     - name: Acquire ROS dependencies
-      uses: ros-tooling/setup-ros@master
+      uses: ros-tooling/setup-ros@v0.2
+      with:
+        use-ros2-testing: true
+        required-ros-distributions: foxy
     - name: Set up git to see all pull requests
       run: git config --global --add remote.origin.fetch '+refs/pull/*:refs/remotes/origin/pull/*'
     - name: Build and test ROS
-      uses: ros-tooling/action-ros-ci@0.0.19
+      uses: ros-tooling/action-ros-ci@v0.2
       with:
         target-ros2-distro: foxy
         package-name: >


### PR DESCRIPTION
- Pin to stable versions of ros-tooling actions
- Remove overlayed version of ament_lint from workspace
  - The related PR has been merged and we should be linting against the version in Foxy anyways
- Do not test against macOS; it is no longer a supported platform for Foxy
- Pull dependencies from the testing repository