### PR TITLE
Call dissociate_reader in rmw_destroy_subscription

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2794,7 +2794,7 @@ extern "C" rmw_ret_t rmw_destroy_subscription(rmw_node_t * node, rmw_subscriptio
     const auto cddssub = static_cast<const CddsSubscription *>(subscription->data);
     std::lock_guard<std::mutex> guard(common->node_update_mutex);
     rmw_dds_common::msg::ParticipantEntitiesInfo msg =
-      common->graph_cache.dissociate_writer(
+      common->graph_cache.dissociate_reader(
       cddssub->gid, common->gid, node->name,
       node->namespace_);
     ret = rmw_publish(common->pub, static_cast<void *>(&msg), nullptr);


### PR DESCRIPTION
A call to dissociate_writer, like it did before, is a no-op.  The result
is that the ros_discovery_info topic sample keeps growing when one
creates and destroy subscriptions in the application.

Signed-off-by: Erik Boasson <eb@ilities.com>