### PR TITLE
Fix a warning by making a pointer nullptr.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2269,7 +2269,7 @@ static CddsPublisher * create_cdds_publisher(
     fqtopic_name.c_str(), type_support->typesupport_identifier,
     create_message_type_support(type_support->data, type_support->typesupport_identifier), false,
     rmw_cyclonedds_cpp::make_message_value_type(type_supports), sample_size, is_fixed_type);
-  struct ddsi_sertype * stact;
+  struct ddsi_sertype * stact = nullptr;
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype, &stact);
 
   dds_listener_t * listener = dds_create_listener(&pub->user_callback_data);


### PR DESCRIPTION
When building on Ubuntu 22.04 in Release mode, gcc complains that:

‘stact’ may be used uninitialized in this function [-Wmaybe-uninitialized] 2295

I think this is probably a false positive; in any situations
where stact was not set, we would have gotten out before this.
Regardless, just set stact to nullptr, which quiets the warning
and should have no deleterious effects.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This should fix warnings from the nightlies like the last one shown in https://ci.ros2.org/view/nightly/job/nightly_linux_release/2205/gcc/new/