### PR TITLE
Update to work with Cyclone 0.9.0 and Iceoryx 2.0

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1880,7 +1880,9 @@ static rmw_ret_t publish_loaned_int(
   // if the publisher allow loaning
   if (cdds_publisher->is_loaning_available) {
     auto d = new serdata_rmw(cdds_publisher->sertype, ddsi_serdata_kind::SDK_DATA);
-    d->iox_chunk = SHIFT_BACK_TO_ICEORYX_HEADER(ros_message);
+    d->iox_chunk = ros_message;
+    // since we write the loaned chunk here, set the data state to raw
+    shm_set_data_state(d->iox_chunk, IOX_CHUNK_CONTAINS_RAW_DATA);
     if (dds_writecdr(cdds_publisher->enth, d) >= 0) {
       return RMW_RET_OK;
     } else {

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -143,9 +143,17 @@ static void serialize_into_serdata_rmw_on_demand(serdata_rmw * d)
   {
     std::lock_guard<std::mutex> lock(type->serialize_lock);
     if (d->iox_chunk && d->data() == nullptr) {
-      serialize_into_serdata_rmw(
-        const_cast<serdata_rmw *>(d),
-        SHIFT_PAST_ICEORYX_HEADER(d->iox_chunk));
+        auto iox_header = iceoryx_header_from_chunk(d->iox_chunk);
+        // if the iox chunk has the data in serialized form
+        if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_SERIALIZED_DATA) {
+          d->resize(iox_header->data_size);
+          memcpy(d->data(), d->iox_chunk, iox_header->data_size);
+          // TODO(Sumanth), free chunk and set to null?
+        } else if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
+            serialize_into_serdata_rmw(const_cast<serdata_rmw *>(d), d->iox_chunk);
+        } else {
+          RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
+        }
     }
   }
 #endif

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -176,7 +176,7 @@ static void serdata_rmw_free(struct ddsi_serdata * dcmn)
 
 #ifdef DDS_HAS_SHM
   if (d->iox_chunk && d->iox_subscriber) {
-    iox_sub_release_chunk(*static_cast<iox_sub_t *>(d->iox_subscriber), d->iox_chunk);
+    free_iox_chunk(static_cast<iox_sub_t *>(d->iox_subscriber), &d->iox_chunk);
     d->iox_chunk = nullptr;
   }
 #endif

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -25,7 +25,7 @@
 #ifdef DDS_HAS_SHM
 #include "dds/ddsi/q_xmsg.h"
 extern "C" {
-#include "dds/ddsi/shm_sync.h"
+#include "dds/ddsi/ddsi_shm_transport.h"
 }
 #endif  // DDS_HAS_SHM
 


### PR DESCRIPTION
Updates `rmw_cyclonedds_cpp` to work with Cyclone 0.9.0 and Iceoryx 2.0

Fixes #378