### PR TITLE
Fix for shared memory transport tests

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2588,6 +2588,10 @@ static rmw_ret_t borrow_loaned_message_int(
     publisher->implementation_identifier,
     eclipse_cyclonedds_identifier,
     return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(ros_message, RMW_RET_INVALID_ARGUMENT);
+  if (*ros_message) {
+    return RMW_RET_INVALID_ARGUMENT;
+  }
   auto cdds_publisher = static_cast<CddsPublisher *>(publisher->data);
   if (!cdds_publisher) {
     RMW_SET_ERROR_MSG("publisher data is null");

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -368,6 +368,7 @@ static bool serdata_rmw_to_sample(
         probably incompatible. */
       cdds_request_wrapper_t * const wrap = static_cast<cdds_request_wrapper_t *>(sample);
       auto prefix = [wrap](cycdeser & ser) {ser >> wrap->header.guid; ser >> wrap->header.seq;};
+      serialize_into_serdata_rmw_on_demand(const_cast<serdata_rmw *>(d));
       cycdeser sd(d->data(), d->size());
       if (using_introspection_c_typesupport(type->type_support.typesupport_identifier_)) {
         auto typed_typesupport =


### PR DESCRIPTION
Adding bug-fixes to rmw_cyclonedds:
- additional checks for `borrow_loaned_message_int` to make sure that no nullptr is passed or when a message is already loaned
- adding serialization in `serdata_rmw_to_sample` when `is_request_header = false` to work with server/client API

@eboasson @MatthiasKillat @sumanth-nirmal 
Would you take a look on this? ~~The PR is currently in Draft state because there is another issue with the node graph that needs investigation.~~