### PR TITLE
Fix get_topic_name and handling long service names

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -5006,8 +5006,7 @@ extern "C" rmw_ret_t rmw_get_service_names_and_types(
 static rmw_ret_t get_topic_name(dds_entity_t endpoint_handle, std::string & name)
 {
   std::vector<char> tmp(128);
-  dds_return_t rc;
-  rc = dds_get_name(dds_get_topic(endpoint_handle), tmp.data(), tmp.size());
+  dds_return_t rc = dds_get_name(dds_get_topic(endpoint_handle), tmp.data(), tmp.size());
   if (rc > 0 && static_cast<size_t>(rc) > tmp.size()) {
     // topic name is too long for the buffer, but now we know how long it is
     tmp.resize(static_cast<size_t>(rc) + 1);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -5019,10 +5019,10 @@ static rmw_ret_t get_topic_name(dds_entity_t endpoint_handle, std::string & name
     // handle reused for something with a longer name (which is exceedingly
     // unlikely), and so it really is an error
     return RMW_RET_ERROR;
-  } else {
-    name = std::string(tmp.begin(), tmp.begin() + rc);
-    return RMW_RET_OK;
   }
+
+  name = std::string(tmp.begin(), tmp.begin() + rc);
+  return RMW_RET_OK;
 }
 
 static rmw_ret_t check_for_service_reader_writer(const CddsCS & client, bool * is_available)

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -5007,7 +5007,7 @@ static rmw_ret_t get_topic_name(dds_entity_t endpoint_handle, std::string & name
 {
   std::vector<char> tmp(128);
   dds_return_t rc = dds_get_name(dds_get_topic(endpoint_handle), tmp.data(), tmp.size());
-  if (rc > 0 && static_cast<size_t>(rc) > tmp.size()) {
+  if (rc > 0 && static_cast<size_t>(rc) >= tmp.size()) {
     // topic name is too long for the buffer, but now we know how long it is
     tmp.resize(static_cast<size_t>(rc) + 1);
     rc = dds_get_name(dds_get_topic(endpoint_handle), tmp.data(), tmp.size());


### PR DESCRIPTION
Determining whether a service is available relies on topic names, but
the function to retrieve a topic name mishandled long names by accepting
a truncated name when the 128-byte buffer passed in was too small
instead of retrying with a larger buffer.

Cyclone DDS' underlying function always returns the actual length of the
name and topic names can't change, and so there is no need to guess or
loop.

Fixes #384

Signed-off-by: Erik Boasson <eb@ilities.com>