### PR TITLE
[Service introspection] populate rmw_client_t.writer_guid

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -4763,6 +4763,9 @@ extern "C" rmw_client_t * rmw_create_client(
   rmw_client->implementation_identifier = eclipse_cyclonedds_identifier;
   rmw_client->data = info;
   rmw_client->service_name = reinterpret_cast<const char *>(rmw_allocate(strlen(service_name) + 1));
+  std::copy(info->client.id.data, info->client.id.data + sizeof(info->client.id.data),
+      rmw_client->writer_guid);
+
   RET_NULL_X(rmw_client->service_name, goto fail_service_name);
   memcpy(const_cast<char *>(rmw_client->service_name), service_name, strlen(service_name) + 1);
 


### PR DESCRIPTION
This PR is a prototype for the service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) implementing the proposed single serialized message approach (https://github.com/ros-infrastructure/rep/pull/360#discussion_r902987531).

This PR implements https://github.com/ros2/rmw/pull/325

Connects to https://github.com/ros2/ros2/issues/1285


