### PR TITLE
Improve error message when create_topic fails

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1787,6 +1787,26 @@ static dds_entity_t create_topic(dds_entity_t pp, const char * name, struct ddsi
   return tp;
 }
 
+void set_error_message_from_create_topic(dds_entity_t topic)
+{
+  assert(topic < 0);
+  if (DDS_RETCODE_BAD_PARAMETER == topic) {
+    RMW_SET_ERROR_MSG(
+      "failed to create topic because the function was given"
+      " invalid parameters");
+  } else if (DDS_RETCODE_INCONSISTENT_POLICY == topic) {
+    RMW_SET_ERROR_MSG(
+      "failed to create topic because it's already in use"
+      " in this context with incompatible QoS settings");
+  } else if (DDS_RETCODE_PRECONDITION_NOT_MET == topic) {
+    RMW_SET_ERROR_MSG(
+      "failed to create topic because it's already in use"
+      " in this context with different message type");
+  } else {
+    RMW_SET_ERROR_MSG("failed to create topic for unknown reasons");
+  }
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 ///////////                                                                   ///////////
 ///////////    PUBLICATIONS                                                   ///////////
@@ -2273,7 +2293,7 @@ static CddsPublisher * create_cdds_publisher(
   listener_set_event_callbacks(listener, &pub->user_callback_data);
 
   if (topic < 0) {
-    RMW_SET_ERROR_MSG("failed to create topic");
+    set_error_message_from_create_topic(topic);
     goto fail_topic;
   }
   if ((qos = create_readwrite_qos(qos_policies, false)) == nullptr) {
@@ -2783,7 +2803,7 @@ static CddsSubscription * create_cdds_subscription(
   listener_set_event_callbacks(listener, &sub->user_callback_data);
 
   if (topic < 0) {
-    RMW_SET_ERROR_MSG("failed to create topic");
+    set_error_message_from_create_topic(topic);
     goto fail_topic;
   }
   if ((qos = create_readwrite_qos(qos_policies, ignore_local_publications)) == nullptr) {
@@ -4615,7 +4635,7 @@ static rmw_ret_t rmw_init_cs(
   struct ddsi_sertype * pub_stact;
   pubtopic = create_topic(node->context->impl->ppant, pubtopic_name.c_str(), pub_st, &pub_stact);
   if (pubtopic < 0) {
-    RMW_SET_ERROR_MSG("failed to create topic");
+    set_error_message_from_create_topic(pubtopic);
     goto fail_pubtopic;
   }
 
@@ -4624,7 +4644,7 @@ static rmw_ret_t rmw_init_cs(
     std::move(sub_msg_ts));
   subtopic = create_topic(node->context->impl->ppant, subtopic_name.c_str(), sub_st);
   if (subtopic < 0) {
-    RMW_SET_ERROR_MSG("failed to create topic");
+    set_error_message_from_create_topic(subtopic);
     goto fail_subtopic;
   }
   // before proceeding to outright ignore given QoS policies, sanity check them

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1801,7 +1801,7 @@ void set_error_message_from_create_topic(dds_entity_t topic)
   } else if (DDS_RETCODE_PRECONDITION_NOT_MET == topic) {
     RMW_SET_ERROR_MSG(
       "failed to create topic because it's already in use"
-      " in this context with different message type");
+      " in this context with a different message type");
   } else {
     RMW_SET_ERROR_MSG("failed to create topic for unknown reasons");
   }


### PR DESCRIPTION
This improves the error message when creating a topic fails. The return codes are the documented return codes for `dds_create_topic_generic` and `dds_create_topic_sertype`, which is what `create_topic()` uses depending on the preprocessor definition `DDS_HAS_DDSI_SERTYPE`.

https://cyclonedds.io/docs/cyclonedds/latest/api/topic.html#c.dds_create_topic_generic
https://cyclonedds.io/docs/cyclonedds/latest/api/topic.html#c.dds_create_topic_sertype

