### PR TITLE
Remove outdated hack for ament_lint

### DIFF
--- a/.github/resources/local.repos
+++ b/.github/resources/local.repos
@@ -10,7 +10,3 @@ repositories:
   ros2/rosidl_typesupport_fastrtps/COLCON_IGNORE: *empty_repo
   ros2/rmw_fastrtps/COLCON_IGNORE: *empty_repo
 
-  ament/ament_lint:
-    type: git
-    url: https://github.com/ament/ament_lint.git
-    version: pull/268/merge


### PR DESCRIPTION
This is causing CI to fail because the referenced patch has been merged and the branch deleted.

https://github.com/ament/ament_lint/pull/268