### PR TITLE
[foxy] Handle allocation errors during message deserialization (#313)

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1445,6 +1445,9 @@ extern "C" rmw_ret_t rmw_deserialize(
   } catch (rmw_cyclonedds_cpp::Exception & e) {
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("rmw_serialize: %s", e.what());
     ok = false;
+  } catch (std::runtime_error & e) {
+    RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("rmw_serialize: %s", e.what());
+    ok = false;
   }
 
   return ok ? RMW_RET_OK : RMW_RET_ERROR;


### PR DESCRIPTION
Backport #313 to Foxy.

This fixes a test failure that cropped up with https://github.com/ros2/rosidl/pull/604

CI together with the connected PR:
- Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=17294)](https://ci.ros2.org/job/ci_linux/17294/)
- Linux-aarch64 [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=11835)](https://ci.ros2.org/job/ci_linux-aarch64/11835/)
- Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=17781)](https://ci.ros2.org/job/ci_windows/17781/)