### PR TITLE
Export CycloneDDS dependency

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -54,6 +54,9 @@ find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
+if(_cyclonedds_has_shm)
+  ament_export_dependencies(iceoryx_binding_c)
+endif()
 ament_export_dependencies(CycloneDDS)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rcpputils)
@@ -62,6 +65,7 @@ ament_export_dependencies(rosidl_runtime_c)
 ament_export_dependencies(rmw_dds_common)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
+ament_export_dependencies(tracetools)
 
 add_library(rmw_cyclonedds_cpp
   src/rmw_get_network_flow_endpoints.cpp

--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -54,6 +54,7 @@ find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
+ament_export_dependencies(CycloneDDS)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rmw)


### PR DESCRIPTION
This fixes a build failure in downstream packages when building with `-DBUILD_SHARED_LIBS=OFF`. The exported `rmw_cyclonedds` CMake target references `$<LINK_ONLY:CylconeDDS:ddsc>`, but `CycloneDDS` hasn't been `find_package()`'d downstream so the target doesn't exist. This PR fixes that.