### PR TITLE
Make sure to add semicolons to the CHECK_TYPE_IDENTIFIER_MATCH.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3327,7 +3327,7 @@ static rmw_ret_t rmw_take_ser_int(
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     subscription handle,
     subscription->implementation_identifier, eclipse_cyclonedds_identifier,
-    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION)
+    return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
   CddsSubscription * sub = static_cast<CddsSubscription *>(subscription->data);
   RET_NULL(sub);
   dds_sample_info_t info;


### PR DESCRIPTION
That way it is an actual C/C++ statement, and we can make minor changes to that macro as needed.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

On its own, this isn't interesting, but I'm going to be doing some minor modifications to the `RMW_CHECK_TYPE_IDENTIFIERS_MATCH` macro that requires this.