### PR TITLE
Clear out errors once we have handled them.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -961,6 +961,8 @@ static void handle_builtintopic_endpoint(
             s->topic_name, s->type_name,
             static_cast<int>(userdata_size), reinterpret_cast<char *>(userdata));
           type_hash = rosidl_get_zero_initialized_type_hash();
+          // We've handled the error, so clear it out.
+          rmw_reset_error();
         }
       }
 
@@ -2294,6 +2296,8 @@ static dds_qos_t * create_readwrite_qos(
       "rmw_cyclonedds_cpp",
       "Failed to encode type hash for topic, will not distribute it in USER_DATA.");
     typehash_str.clear();
+    // We've handled the error, so clear it out.
+    rmw_reset_error();
   }
   std::string user_data = extra_user_data + typehash_str;
   dds_qset_userdata(qos, user_data.data(), user_data.size());


### PR DESCRIPTION
In particular, in the type-hash code we can handle a failure to encode or parse the type hash from the user data.  Once we've handled it, and printed out an error about it, we should clear it because we are going to continue on and something else down the line might have an error.

This will avoid errors like:

This error state is being overwritten:

 <old message>

with this new error message:

 <new message>