### PR TITLE
Remove a bunch of unnecessary macros.

### DIFF
--- a/rmw_cyclonedds_cpp/src/serdes.hpp
+++ b/rmw_cyclonedds_cpp/src/serdes.hpp
@@ -174,24 +174,27 @@ public:
     pos += sz * sizeof(wchar_t);
   }
 
+  // *INDENT-OFF*
 #define DESER8_A(T) DESER_A(T, )
 #define DESER_A(T, fn_swap) inline void deserializeA(T * x, size_t cnt) { \
-    if (cnt > 0) { \
-      align(sizeof(T)); \
-      validate_size(cnt, sizeof(T)); \
-      if (swap_bytes) { \
-        for (size_t i = 0; i < cnt; i++) { \
-          x[i] = fn_swap(*reinterpret_cast<const T *>(data + pos)); \
-          pos += sizeof(T); \
-        } \
-      } else { \
-        memcpy( \
-          reinterpret_cast<void *>(x), reinterpret_cast<const void *>(data + pos), \
-          cnt * sizeof(T)); \
-        pos += cnt * sizeof(T); \
+  if (cnt > 0) { \
+    align(sizeof(T)); \
+    validate_size(cnt, sizeof(T)); \
+    if (swap_bytes) { \
+      for (size_t i = 0; i < cnt; i++) { \
+        x[i] = fn_swap(*reinterpret_cast<const T *>(data + pos)); \
+        pos += sizeof(T); \
       } \
+    } else { \
+      memcpy( \
+        reinterpret_cast<void *>(x), reinterpret_cast<const void *>(data + pos), \
+        cnt * sizeof(T)); \
+      pos += cnt * sizeof(T); \
     } \
+  } \
 }
+  // *INDENT-ON*
+
   DESER8_A(char);
   DESER8_A(int8_t);
   DESER8_A(uint8_t);


### PR DESCRIPTION
The main goal here is to sidestep differences between uncrustify 0.72 and 0.78.  However, I realized that a lot of these macros were either duplicating functionality we already had, or were just as long as "inlining" the code would be.  Just get rid of these macros.

In the one place that we can't do this, just mark the macro as not to be indented by uncrustify.