### PR TITLE
Make rmw_service_server_is_available return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -5464,15 +5464,15 @@ extern "C" rmw_ret_t rmw_service_server_is_available(
   const rmw_client_t * client,
   bool * is_available)
 {
-  RET_NULL(node);
+  RMW_CHECK_ARGUMENT_FOR_NULL(node, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     node, node->implementation_identifier,
     eclipse_cyclonedds_identifier, return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RET_NULL(client);
+  RMW_CHECK_ARGUMENT_FOR_NULL(client, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     client, client->implementation_identifier,
     eclipse_cyclonedds_identifier, return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);
-  RET_NULL(is_available);
+  RMW_CHECK_ARGUMENT_FOR_NULL(is_available, RMW_RET_INVALID_ARGUMENT);
   *is_available = false;
 
   auto info = static_cast<CddsClient *>(client->data);


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/277 changed the `rmw_service_server_is_available()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `node`, `client`, or `is_available` are `NULL`. However, this wasn't the case in practice in the implementations of `rmw_service_server_is_available()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/231