### PR TITLE
Use rmw_namespace_validation_result_string() in rmw_create_node

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1698,7 +1698,7 @@ extern "C" rmw_node_t * rmw_create_node(
     return nullptr;
   }
   if (RMW_NAMESPACE_VALID != validation_result) {
-    const char * reason = rmw_node_name_validation_result_string(validation_result);
+    const char * reason = rmw_namespace_validation_result_string(validation_result);
     RMW_SET_ERROR_MSG_WITH_FORMAT_STRING("invalid node namespace: %s", reason);
     return nullptr;
   }


### PR DESCRIPTION
`rmw_namespace_validation_result_string()` -- not `rmw_node_name_validation_result_string()` -- should be called with the validation result from `rmw_validate_namespace()`.

In practice, this meant that the reason given might have been `"unknown result code for rmw node name validation"` given that `rmw_node_name_validation_result_string()` doesn't know about all validation results from `rmw_validate_namespace()`. However, I believe that we don't test these error messages anywhere and rarely rely on them, so it doesn't/shouldn't affect any tests or functionality.

Related PRs:

* https://github.com/ros2/rmw_fastrtps/pull/765
* https://github.com/ros2/rmw_connextdds/pull/151
* https://github.com/ros2/rmw_zenoh/pull/196