### PR TITLE
Make rmw_destroy_wait_set return RMW_RET_INVALID_ARGUMENT

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -4195,7 +4195,7 @@ fail_alloc_wait_set:
 
 extern "C" rmw_ret_t rmw_destroy_wait_set(rmw_wait_set_t * wait_set)
 {
-  RET_NULL(wait_set);
+  RMW_CHECK_ARGUMENT_FOR_NULL(wait_set, RMW_RET_INVALID_ARGUMENT);
   RMW_CHECK_TYPE_IDENTIFIERS_MATCH(
     wait_set, wait_set->implementation_identifier,
     eclipse_cyclonedds_identifier, return RMW_RET_INCORRECT_RMW_IMPLEMENTATION);


### PR DESCRIPTION
https://github.com/ros2/rmw/pull/275 changed the `rmw_destroy_wait_set()` API documentation to indicate that it returns `RMW_RET_INVALID_ARGUMENT` if `wait_set` is `NULL`. However, this wasn't the case in practice in the implementations of `rmw_destroy_wait_set()` or in the relevant test.

Change the implementation here to return `RMW_RET_INVALID_ARGUMENT`.

Requires https://github.com/ros2/rmw_implementation/pull/234