### PR TITLE
Support Cyclone DDS v0.10.x and master + ROS 2 type definitions in DDS

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -34,13 +34,16 @@ find_package(tracetools REQUIRED)
 
 find_package(CycloneDDS QUIET CONFIG)
 if(CycloneDDS_FOUND)
-  # Support for shared memory in RMW depends on support for shared memory being compiled in
-  # Cyclone DDS and iceoryx_binding_c being available
-  get_target_property(_cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)
-  if(_cyclonedds_has_shm)
-    find_package(iceoryx_binding_c REQUIRED)
-  else()
-    message(STATUS "Cyclone DDS is NOT compiled with support for shared memory")
+  if(CycloneDDS_VERSION VERSION_LESS 0.11)
+    # Support for shared memory in RMW depends on support for shared memory being compiled
+    # in Cyclone DDS for Cyclone version 0.10.x (and older) and iceoryx_binding_c being
+    # available
+    get_target_property(_cyclonedds_has_shm CycloneDDS::ddsc SHM_SUPPORT_IS_AVAILABLE)
+    if(_cyclonedds_has_shm)
+      find_package(iceoryx_binding_c REQUIRED)
+    else()
+      message(STATUS "Cyclone DDS is NOT compiled with support for shared memory")
+    endif()
   endif()
 else()
   message(WARNING "Could not find Eclipse Cyclone DDS - skipping '${PROJECT_NAME}'")
@@ -81,6 +84,9 @@ add_library(rmw_cyclonedds_cpp
   src/Serialization.cpp
   src/TypeSupport2.cpp
   src/TypeSupport.cpp)
+
+configure_file("src/cdds_version.hpp.in" "src/cdds_version.hpp")
+target_include_directories(rmw_cyclonedds_cpp PRIVATE ${CMAKE_BINARY_DIR}/src)
 
 target_link_libraries(rmw_cyclonedds_cpp PUBLIC
   rmw::rmw)

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_ros_core</buildtool_depend>
 
   <depend>cyclonedds</depend>
+  <!-- Iceoryx not a build dependency for Cyclone versions greater than 0.10 -->
   <depend>iceoryx_binding_c</depend>
   <depend>rcutils</depend>
   <depend>rcpputils</depend>

--- a/rmw_cyclonedds_cpp/src/cdds_version.hpp.in
+++ b/rmw_cyclonedds_cpp/src/cdds_version.hpp.in
@@ -1,0 +1,22 @@
+// Copyright 2024 ZettaScale Technology
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef CDDS_VERSION_HPP_
+#define CDDS_VERSION_HPP_
+
+#define CDDS_VERSION_0_10 10
+#define CDDS_VERSION_0_11 11
+
+#define CDDS_VERSION (@CycloneDDS_VERSION_MAJOR@ * 100 + @CycloneDDS_VERSION_MINOR@)
+
+#endif  // CDDS_VERSION_HPP_

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -88,11 +88,15 @@
 #include "namespace_prefix.hpp"
 
 #include "dds/dds.h"
+#include "cdds_version.hpp"
+#if CDDS_VERSION == CDDS_VERSION_0_10 && defined DDS_HAS_SHM
 #include "dds/ddsc/dds_data_allocator.h"
 #include "dds/ddsc/dds_loan_api.h"
+#endif
 #include "serdes.hpp"
 #include "serdata.hpp"
 #include "demangle.hpp"
+
 
 using namespace std::literals::chrono_literals;
 
@@ -101,10 +105,6 @@ using namespace std::literals::chrono_literals;
 #define RMW_SUPPORT_SECURITY 1
 #else
 #define RMW_SUPPORT_SECURITY 0
-#endif
-
-#if !DDS_HAS_DDSI_SERTYPE
-#define ddsi_sertype_unref(x) ddsi_sertopic_unref(x)
 #endif
 
 /* Set to > 0 for printing warnings to stderr for each messages that was taken more than this many
@@ -344,7 +344,9 @@ struct CddsPublisher : CddsEntity
   rmw_gid_t gid;
   struct ddsi_sertype * sertype;
   rosidl_message_type_support_t type_supports;
+#if CDDS_VERSION == CDDS_VERSION_0_10
   dds_data_allocator_t data_allocator;
+#endif
   uint32_t sample_size;
   bool is_loaning_available;
   user_callback_data_t user_callback_data;
@@ -355,7 +357,9 @@ struct CddsSubscription : CddsEntity
   rmw_gid_t gid;
   dds_entity_t rdcondh;
   rosidl_message_type_support_t type_supports;
+#if CDDS_VERSION == CDDS_VERSION_0_10
   dds_data_allocator_t data_allocator;
+#endif
   bool is_loaning_available;
   user_callback_data_t user_callback_data;
 };
@@ -1563,6 +1567,7 @@ static void * init_and_alloc_sample(
   entityT & entity, const uint32_t sample_size, const bool alloc_on_heap = false)
 {
   // initialise the data allocator
+#if CDDS_VERSION == CDDS_VERSION_0_10
   if (alloc_on_heap) {
     if (dds_data_allocator_init_heap(&entity->data_allocator) != DDS_RETCODE_OK) {
       RMW_SET_ERROR_MSG("Reader data allocator initialization failed for heap");
@@ -1577,6 +1582,9 @@ static void * init_and_alloc_sample(
   // allocate memory for message + header
   // the header will be initialized and the chunk pointer will be returned
   auto chunk_ptr = dds_data_allocator_alloc(&entity->data_allocator, sample_size);
+#else
+  auto chunk_ptr = dds_request_loan_of_size(entity->enth, sample_size);
+#endif
   RMW_CHECK_FOR_NULL_WITH_MSG(
     chunk_ptr,
     "Failed to get loan",
@@ -1592,6 +1600,7 @@ static rmw_ret_t fini_and_free_sample(entityT & entity, void * loaned_message)
 {
   // fini the message
   rmw_cyclonedds_cpp::fini_message(&entity->type_supports, loaned_message);
+#if CDDS_VERSION == CDDS_VERSION_0_10
   // free the message memory
   if (dds_data_allocator_free(&entity->data_allocator, loaned_message) != DDS_RETCODE_OK) {
     RMW_SET_ERROR_MSG("Failed to free the loaned message");
@@ -1602,6 +1611,12 @@ static rmw_ret_t fini_and_free_sample(entityT & entity, void * loaned_message)
     RMW_SET_ERROR_MSG("Failed to fini data allocator");
     return RMW_RET_ERROR;
   }
+#else
+  if (dds_return_loan(entity->enth, loaned_message) != DDS_RETCODE_OK) {
+    RMW_SET_ERROR_MSG("Failed to free the loaned message");
+    return RMW_RET_ERROR;
+  }
+#endif
   return RMW_RET_OK;
 }
 
@@ -1933,12 +1948,7 @@ static dds_entity_t create_topic(
   struct ddsi_sertype ** stact)
 {
   dds_entity_t tp;
-#if DDS_HAS_DDSI_SERTYPE
   tp = dds_create_topic_sertype(pp, name, &sertype, nullptr, nullptr, nullptr);
-#else
-  static_cast<void>(name);
-  tp = dds_create_topic_generic(pp, &sertype, nullptr, nullptr, nullptr);
-#endif
   if (tp < 0) {
     ddsi_sertype_unref(sertype);
   } else {
@@ -2482,9 +2492,9 @@ static CddsPublisher * create_cdds_publisher(
 
   auto sertype = create_sertype(
     type_support->typesupport_identifier,
-    create_message_type_support(type_support->data, type_support->typesupport_identifier), 
+    create_message_type_support(type_support->data, type_support->typesupport_identifier),
     false,
-    rmw_cyclonedds_cpp::make_message_value_type(type_supports), 
+    rmw_cyclonedds_cpp::make_message_value_type(type_supports),
     sample_size, is_fixed_type);
   create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
   struct ddsi_sertype * stact = nullptr;
@@ -2516,7 +2526,15 @@ static CddsPublisher * create_cdds_publisher(
   pub->sertype = stact;
   dds_delete_listener(listener);
   pub->type_supports = *type_supports;
+#if CDDS_VERSION == CDDS_VERSION_0_10
   pub->is_loaning_available = is_fixed_type && dds_is_loan_available(pub->enth);
+#else
+  // Some form of loaning is always possible, but the exact behaviour depends on type and
+  // whether or not Iceoryx can be used.  I'm not sure to what the expectations are
+  // exactly, this should keep it essentially unchanged from the behaviour in Humble and
+  // Iron.
+  pub->is_loaning_available = is_fixed_type && dds_is_shared_memory_available(pub->enth);
+#endif
   pub->sample_size = sample_size;
   dds_delete_qos(qos);
   dds_delete(topic);
@@ -2992,9 +3010,9 @@ static CddsSubscription * create_cdds_subscription(
 
   auto sertype = create_sertype(
     type_support->typesupport_identifier,
-    create_message_type_support(type_support->data, type_support->typesupport_identifier), 
+    create_message_type_support(type_support->data, type_support->typesupport_identifier),
     false,
-    rmw_cyclonedds_cpp::make_message_value_type(type_supports), 
+    rmw_cyclonedds_cpp::make_message_value_type(type_supports),
     sample_size, is_fixed_type);
   create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype);
@@ -3026,7 +3044,15 @@ static CddsSubscription * create_cdds_subscription(
   }
   dds_delete_listener(listener);
   sub->type_supports = *type_support;
+#if CDDS_VERSION == CDDS_VERSION_0_10
   sub->is_loaning_available = is_fixed_type && dds_is_loan_available(sub->enth);
+#else
+  // Some form of loaning is always possible, but the exact behaviour depends on type and
+  // whether or not Iceoryx can be used.  I'm not sure to what the expectations are
+  // exactly, this should keep it essentially unchanged from the behaviour in Humble and
+  // Iron.
+  sub->is_loaning_available = is_fixed_type && dds_is_shared_memory_available(sub->enth);
+#endif
   dds_delete_qos(qos);
   dds_delete(topic);
 
@@ -3632,10 +3658,12 @@ static rmw_ret_t rmw_take_loan_int(
           return RMW_RET_ERROR;
         }
         *taken = true;
+#if CDDS_VERSION == CDDS_VERSION_0_10
         // doesn't allocate, but initialise the allocator to free the chunk later when the loan
         // is returned
         dds_data_allocator_init(
           cdds_subscription->enth, &cdds_subscription->data_allocator);
+#endif
         // set the loaned chunk to null, so that the  loaned chunk is not release in
         // rmw_serdata_free(), but will be released when
         // `rmw_return_loaned_message_from_subscription()` is called
@@ -5043,12 +5071,10 @@ static rmw_ret_t rmw_init_cs(
   std::string user_data;
 
   std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> pub_msg_ts, sub_msg_ts;
+  struct sertype_rmw * pub_st, * sub_st;
 
   dds_listener_t * listener = dds_create_listener(cb_data);
   dds_lset_data_available_arg(listener, dds_listener_callback, cb_data, false);
-  
-
-  struct sertype_rmw * pub_st, * sub_st;
 
   if (is_service) {
     std::tie(sub_msg_ts, pub_msg_ts) =
@@ -5076,7 +5102,6 @@ static rmw_ret_t rmw_init_cs(
       std::move(sub_msg_ts), 0U, false
     );
     create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
-  
   } else {
     std::tie(pub_msg_ts, sub_msg_ts) =
       rmw_cyclonedds_cpp::make_request_response_value_types(type_supports);
@@ -5092,7 +5117,7 @@ static rmw_ret_t rmw_init_cs(
     pubtopic_name =
       make_fqtopic(ROS_SERVICE_REQUESTER_PREFIX, service_name, "Request", qos_policies);
     subtopic_name = make_fqtopic(ROS_SERVICE_RESPONSE_PREFIX, service_name, "Reply", qos_policies);
-    
+
     pub_st = create_sertype(
       type_support->typesupport_identifier, pub_type_support, true,
       std::move(pub_msg_ts), 0U, false
@@ -5103,7 +5128,6 @@ static rmw_ret_t rmw_init_cs(
       std::move(sub_msg_ts), 0U, false
     );
     create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
-
   }
 
   RCUTILS_LOG_DEBUG_NAMED(
@@ -5114,14 +5138,14 @@ static rmw_ret_t rmw_init_cs(
   RCUTILS_LOG_DEBUG_NAMED("rmw_cyclonedds_cpp", "***********");
 
   dds_entity_t pubtopic, subtopic;
-  
+
   struct ddsi_sertype * pub_stact;
   pubtopic = create_topic(node->context->impl->ppant, pubtopic_name.c_str(), pub_st, &pub_stact);
   if (pubtopic < 0) {
     set_error_message_from_create_topic(pubtopic, pubtopic_name);
     goto fail_pubtopic;
   }
-  
+
   subtopic = create_topic(node->context->impl->ppant, subtopic_name.c_str(), sub_st);
   if (subtopic < 0) {
     set_error_message_from_create_topic(subtopic, subtopic_name);
@@ -5168,8 +5192,8 @@ static rmw_ret_t rmw_init_cs(
   dds_delete_listener(listener);
   dds_delete_qos(pub_qos);
   dds_delete_qos(sub_qos);
-  dds_delete(pubtopic);
   dds_delete(subtopic);
+  dds_delete(pubtopic);
 
   cs->pub = std::move(pub);
   cs->sub = std::move(sub);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -2496,7 +2496,8 @@ static CddsPublisher * create_cdds_publisher(
     false,
     rmw_cyclonedds_cpp::make_message_value_type(type_supports),
     sample_size, is_fixed_type);
-  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
+  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant,
+    sertype);
   struct ddsi_sertype * stact = nullptr;
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype, &stact);
 
@@ -3014,7 +3015,8 @@ static CddsSubscription * create_cdds_subscription(
     false,
     rmw_cyclonedds_cpp::make_message_value_type(type_supports),
     sample_size, is_fixed_type);
-  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
+  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant,
+    sertype);
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype);
 
   dds_listener_t * listener = dds_create_listener(&sub->user_callback_data);
@@ -5096,12 +5098,14 @@ static rmw_ret_t rmw_init_cs(
       type_support->typesupport_identifier, pub_type_support, true,
       std::move(pub_msg_ts), 0U, false
     );
-    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, pub_st);
+    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data,
+      node->context->impl->ppant, pub_st);
     sub_st = create_sertype(
       type_support->typesupport_identifier, sub_type_support, true,
       std::move(sub_msg_ts), 0U, false
     );
-    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
+    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data,
+      node->context->impl->ppant, sub_st);
   } else {
     std::tie(pub_msg_ts, sub_msg_ts) =
       rmw_cyclonedds_cpp::make_request_response_value_types(type_supports);
@@ -5122,12 +5126,14 @@ static rmw_ret_t rmw_init_cs(
       type_support->typesupport_identifier, pub_type_support, true,
       std::move(pub_msg_ts), 0U, false
     );
-    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, pub_st);
+    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data,
+      node->context->impl->ppant, pub_st);
     sub_st = create_sertype(
       type_support->typesupport_identifier, sub_type_support, true,
       std::move(sub_msg_ts), 0U, false
     );
-    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
+    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data,
+      node->context->impl->ppant, sub_st);
   }
 
   RCUTILS_LOG_DEBUG_NAMED(

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1583,7 +1583,11 @@ static void * init_and_alloc_sample(
   // the header will be initialized and the chunk pointer will be returned
   auto chunk_ptr = dds_data_allocator_alloc(&entity->data_allocator, sample_size);
 #else
-  auto chunk_ptr = dds_request_loan_of_size(entity->enth, sample_size);
+  static_cast<void>(alloc_on_heap);
+  void *chunk_ptr;
+  if (dds_request_loan_of_size(entity->enth, sample_size, &chunk_ptr) != DDS_RETCODE_OK) {
+    chunk_ptr = nullptr;
+  }
 #endif
   RMW_CHECK_FOR_NULL_WITH_MSG(
     chunk_ptr,
@@ -1612,7 +1616,7 @@ static rmw_ret_t fini_and_free_sample(entityT & entity, void * loaned_message)
     return RMW_RET_ERROR;
   }
 #else
-  if (dds_return_loan(entity->enth, loaned_message) != DDS_RETCODE_OK) {
+  if (dds_return_loan(entity->enth, 1, &loaned_message) != DDS_RETCODE_OK) {
     RMW_SET_ERROR_MSG("Failed to free the loaned message");
     return RMW_RET_ERROR;
   }

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1225,7 +1225,6 @@ static bool check_create_domain(dds_domainid_t did, rmw_discovery_options_t * di
         }
         config += "</Peers>";
       }
-
       /* NOTE: Empty configuration fragments are ignored, so it is safe to
         unconditionally append a comma. */
       config += "</Discovery></Domain></CycloneDDS>,";
@@ -2313,6 +2312,7 @@ static rmw_qos_policy_kind_t dds_qos_policy_to_rmw_qos_policy(dds_qos_policy_id_
     case DDS_LIFESPAN_QOS_POLICY_ID:
       return RMW_QOS_POLICY_LIFESPAN;
     default:
+      RCUTILS_LOG_ERROR_NAMED("rmw_cyclonedds_cpp", "%d", policy_id);
       return RMW_QOS_POLICY_INVALID;
   }
 }
@@ -2479,10 +2479,14 @@ static CddsPublisher * create_cdds_publisher(
   std::string fqtopic_name = make_fqtopic(ROS_TOPIC_PREFIX, topic_name, "", qos_policies);
   bool is_fixed_type = is_type_self_contained(type_support);
   uint32_t sample_size = static_cast<uint32_t>(rmw_cyclonedds_cpp::get_message_size(type_support));
+
   auto sertype = create_sertype(
     type_support->typesupport_identifier,
-    create_message_type_support(type_support->data, type_support->typesupport_identifier), false,
-    rmw_cyclonedds_cpp::make_message_value_type(type_supports), sample_size, is_fixed_type);
+    create_message_type_support(type_support->data, type_support->typesupport_identifier), 
+    false,
+    rmw_cyclonedds_cpp::make_message_value_type(type_supports), 
+    sample_size, is_fixed_type);
+  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
   struct ddsi_sertype * stact = nullptr;
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype, &stact);
 
@@ -2507,6 +2511,7 @@ static CddsPublisher * create_cdds_publisher(
     RMW_SET_ERROR_MSG("failed to get instance handle for writer");
     goto fail_instance_handle;
   }
+
   get_entity_gid(pub->enth, pub->gid);
   pub->sertype = stact;
   dds_delete_listener(listener);
@@ -2515,6 +2520,7 @@ static CddsPublisher * create_cdds_publisher(
   pub->sample_size = sample_size;
   dds_delete_qos(qos);
   dds_delete(topic);
+
   return pub;
 
 fail_instance_handle:
@@ -2983,10 +2989,14 @@ static CddsSubscription * create_cdds_subscription(
   std::string fqtopic_name = make_fqtopic(ROS_TOPIC_PREFIX, topic_name, "", qos_policies);
   bool is_fixed_type = is_type_self_contained(type_support);
   uint32_t sample_size = static_cast<uint32_t>(rmw_cyclonedds_cpp::get_message_size(type_support));
+
   auto sertype = create_sertype(
     type_support->typesupport_identifier,
-    create_message_type_support(type_support->data, type_support->typesupport_identifier), false,
-    rmw_cyclonedds_cpp::make_message_value_type(type_supports), sample_size, is_fixed_type);
+    create_message_type_support(type_support->data, type_support->typesupport_identifier), 
+    false,
+    rmw_cyclonedds_cpp::make_message_value_type(type_supports), 
+    sample_size, is_fixed_type);
+  create_msg_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, dds_ppant, sertype);
   topic = create_topic(dds_ppant, fqtopic_name.c_str(), sertype);
 
   dds_listener_t * listener = dds_create_listener(&sub->user_callback_data);
@@ -3019,6 +3029,7 @@ static CddsSubscription * create_cdds_subscription(
   sub->is_loaning_available = is_fixed_type && dds_is_loan_available(sub->enth);
   dds_delete_qos(qos);
   dds_delete(topic);
+
   return sub;
 fail_readcond:
   if (dds_delete(sub->enth) < 0) {
@@ -5035,6 +5046,9 @@ static rmw_ret_t rmw_init_cs(
 
   dds_listener_t * listener = dds_create_listener(cb_data);
   dds_lset_data_available_arg(listener, dds_listener_callback, cb_data, false);
+  
+
+  struct sertype_rmw * pub_st, * sub_st;
 
   if (is_service) {
     std::tie(sub_msg_ts, pub_msg_ts) =
@@ -5051,6 +5065,18 @@ static rmw_ret_t rmw_init_cs(
     subtopic_name =
       make_fqtopic(ROS_SERVICE_REQUESTER_PREFIX, service_name, "Request", qos_policies);
     pubtopic_name = make_fqtopic(ROS_SERVICE_RESPONSE_PREFIX, service_name, "Reply", qos_policies);
+
+    pub_st = create_sertype(
+      type_support->typesupport_identifier, pub_type_support, true,
+      std::move(pub_msg_ts), 0U, false
+    );
+    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, pub_st);
+    sub_st = create_sertype(
+      type_support->typesupport_identifier, sub_type_support, true,
+      std::move(sub_msg_ts), 0U, false
+    );
+    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
+  
   } else {
     std::tie(pub_msg_ts, sub_msg_ts) =
       rmw_cyclonedds_cpp::make_request_response_value_types(type_supports);
@@ -5066,6 +5092,18 @@ static rmw_ret_t rmw_init_cs(
     pubtopic_name =
       make_fqtopic(ROS_SERVICE_REQUESTER_PREFIX, service_name, "Request", qos_policies);
     subtopic_name = make_fqtopic(ROS_SERVICE_RESPONSE_PREFIX, service_name, "Reply", qos_policies);
+    
+    pub_st = create_sertype(
+      type_support->typesupport_identifier, pub_type_support, true,
+      std::move(pub_msg_ts), 0U, false
+    );
+    create_req_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, pub_st);
+    sub_st = create_sertype(
+      type_support->typesupport_identifier, sub_type_support, true,
+      std::move(sub_msg_ts), 0U, false
+    );
+    create_res_dds_dynamic_type(type_support->typesupport_identifier, type_support->data, node->context->impl->ppant, sub_st);
+
   }
 
   RCUTILS_LOG_DEBUG_NAMED(
@@ -5076,21 +5114,14 @@ static rmw_ret_t rmw_init_cs(
   RCUTILS_LOG_DEBUG_NAMED("rmw_cyclonedds_cpp", "***********");
 
   dds_entity_t pubtopic, subtopic;
-  struct sertype_rmw * pub_st, * sub_st;
-
-  pub_st = create_sertype(
-    type_support->typesupport_identifier, pub_type_support, true,
-    std::move(pub_msg_ts));
+  
   struct ddsi_sertype * pub_stact;
   pubtopic = create_topic(node->context->impl->ppant, pubtopic_name.c_str(), pub_st, &pub_stact);
   if (pubtopic < 0) {
     set_error_message_from_create_topic(pubtopic, pubtopic_name);
     goto fail_pubtopic;
   }
-
-  sub_st = create_sertype(
-    type_support->typesupport_identifier, sub_type_support, true,
-    std::move(sub_msg_ts));
+  
   subtopic = create_topic(node->context->impl->ppant, subtopic_name.c_str(), sub_st);
   if (subtopic < 0) {
     set_error_message_from_create_topic(subtopic, subtopic_name);
@@ -5137,8 +5168,8 @@ static rmw_ret_t rmw_init_cs(
   dds_delete_listener(listener);
   dds_delete_qos(pub_qos);
   dds_delete_qos(sub_qos);
-  dds_delete(subtopic);
   dds_delete(pubtopic);
+  dds_delete(subtopic);
 
   cs->pub = std::move(pub);
   cs->sub = std::move(sub);

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -47,6 +47,14 @@
 #include "dds/ddsi/ddsi_typelib.h"
 #endif
 
+// When non-zero throw an exception when dynamic type construction fails.  Right now, it
+// should handle everything but WStrings fine, but those are part of the test suite.
+//
+// Not having a dynamic type associated with the topic doesn't do damage, it just means
+// the integration with the DDS type system is missing just like when you don't do this at
+// all.
+#define THROW_ON_DYNAMIC_TYPE_ERROR 0
+
 using TypeSupport_c =
   rmw_cyclonedds_cpp::TypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
 using TypeSupport_cpp =
@@ -1157,8 +1165,10 @@ void create_msg_dds_dynamic_type(const char * type_support_identifier, const voi
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members))
       dynamic_type_register(st, dstruct, dds_ppant);
+#if THROW_ON_DYNAMIC_TYPE_ERROR
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else if (using_introspection_cpp_typesupport(type_support_identifier)) 
   {
@@ -1170,8 +1180,10 @@ void create_msg_dds_dynamic_type(const char * type_support_identifier, const voi
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members))
       dynamic_type_register(st, dstruct, dds_ppant);
+#if THROW_ON_DYNAMIC_TYPE_ERROR
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else 
   {
@@ -1198,8 +1210,10 @@ void create_req_dds_dynamic_type(const char * type_support_identifier, const voi
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members->request_members_))
       dynamic_type_register(st, dstruct, dds_ppant);
+#if THROW_ON_DYNAMIC_TYPE_ERROR
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else if (using_introspection_cpp_typesupport(type_support_identifier)) 
   {
@@ -1211,8 +1225,10 @@ void create_req_dds_dynamic_type(const char * type_support_identifier, const voi
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members->request_members_))
       dynamic_type_register(st, dstruct, dds_ppant);
+#if THROW_ON_DYNAMIC_TYPE_ERROR
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else 
   {
@@ -1238,9 +1254,11 @@ void create_res_dds_dynamic_type(const char * type_support_identifier, const voi
     dds_dynamic_type_set_extensibility(&dstruct, DDS_DYNAMIC_TYPE_EXT_FINAL);
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members->response_members_))
-      dynamic_type_register(st, dstruct, dds_ppant); 
+      dynamic_type_register(st, dstruct, dds_ppant);
+#if THROW_ON_DYNAMIC_TYPE_ERROR    
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else if (using_introspection_cpp_typesupport(type_support_identifier)) 
   {
@@ -1251,8 +1269,10 @@ void create_res_dds_dynamic_type(const char * type_support_identifier, const voi
 
     if (construct_dds_dynamic_type(&dstruct, dds_ppant, members->response_members_))
       dynamic_type_register(st, dstruct, dds_ppant); 
+#if THROW_ON_DYNAMIC_TYPE_ERROR
     else
-     throw std::runtime_error("construct_dds_dynamic_type failed");
+      throw std::runtime_error("construct_dds_dynamic_type failed");
+#endif
   } 
   else 
   {

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -21,26 +21,31 @@
 #include <utility>
 
 #include "dds/dds.h"
-#ifdef DDS_DYNAMIC_TYPE_SPEC
-#define HAS_DYNAMIC_TYPE
-#include "dds/ddsi/ddsi_radmin.h"
-#else
-#include "dds/ddsi/q_radmin.h"
-#define ddsi_rdata nn_rdata
-#define DDSI_RMSG_PAYLOADOFF(rmsg,rdata) NN_RMSG_PAYLOADOFF((rmsg), (rdata))
-#define DDSI_RDATA_PAYLOAD_OFF(rdata) NN_RDATA_PAYLOAD_OFF((rdata))
-#endif
+#include "cdds_version.hpp"
+
 #include "rmw/allocators.h"
 #include "Serialization.hpp"
 #include "TypeSupport2.hpp"
 #include "bytewise.hpp"
-#include "dds/ddsrt/string.h"
-#include "dds/ddsrt/heap.h"
-#include "dds/ddsc/dds_data_allocator.h"
+#if CDDS_VERSION == CDDS_VERSION_0_10
+#include "dds/ddsi/q_radmin.h"
+#define ddsi_rdata nn_rdata
+#define DDSI_RMSG_PAYLOADOFF(rmsg,rdata) NN_RMSG_PAYLOADOFF((rmsg), (rdata))
+#define DDSI_RDATA_PAYLOAD_OFF(rdata) NN_RDATA_PAYLOAD_OFF((rdata))
+#else
+#include "dds/ddsi/ddsi_radmin.h"
+#include "dds/ddsc/dds_psmx.h"
+#endif
 #include "rmw/error_handling.h"
 #include "MessageTypeSupport.hpp"
 #include "ServiceTypeSupport.hpp"
 #include "serdes.hpp"
+
+#if DDS_HAS_TYPELIB
+#include "dds/ddsrt/string.h"
+#include "dds/ddsrt/heap.h"
+#include "dds/ddsi/ddsi_typelib.h"
+#endif
 
 using TypeSupport_c =
   rmw_cyclonedds_cpp::TypeSupport<rosidl_typesupport_introspection_c__MessageMembers>;
@@ -154,7 +159,22 @@ static void serialize_into_serdata_rmw(serdata_rmw * d, const void * sample)
 
 static void serialize_into_serdata_rmw_on_demand(serdata_rmw * d)
 {
-#ifdef DDS_HAS_SHM
+#if CDDS_VERSION > CDDS_VERSION_0_10
+  auto type = const_cast<sertype_rmw *>(static_cast<const sertype_rmw *>(d->type));
+  {
+    std::lock_guard<std::mutex> lock(type->serialize_lock);
+    if (d->loan && d->data() == nullptr) {
+      if (d->loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_SERIALIZED_DATA) {
+        d->resize(d->loan->metadata->sample_size);
+        memcpy(d->data(), d->loan->sample_ptr, d->loan->metadata->sample_size);
+      } else if (d->loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_RAW_DATA) {
+        serialize_into_serdata_rmw(const_cast<serdata_rmw *>(d), d->loan->sample_ptr);
+      } else {
+        RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
+      }
+    }
+  }
+#elif defined DDS_HAS_SHM
   auto type = const_cast<sertype_rmw *>(static_cast<const sertype_rmw *>(d->type));
   {
     std::lock_guard<std::mutex> lock(type->serialize_lock);
@@ -189,7 +209,11 @@ static void serdata_rmw_free(struct ddsi_serdata * dcmn)
 {
   auto * d = static_cast<serdata_rmw *>(dcmn);
 
-#ifdef DDS_HAS_SHM
+#if CDDS_VERSION > CDDS_VERSION_0_10
+  if (d->loan) {
+    dds_loaned_sample_unref (d->loan);
+  }
+#elif defined DDS_HAS_SHM
   if (d->iox_chunk && d->iox_subscriber) {
     free_iox_chunk(static_cast<iox_sub_t *>(d->iox_subscriber), &d->iox_chunk);
     d->iox_chunk = nullptr;
@@ -263,7 +287,7 @@ static struct ddsi_serdata * serdata_rmw_from_keyhash(
   return new serdata_rmw(type, SDK_KEY);
 }
 
-static struct ddsi_serdata * serdata_rmw_from_sample(
+static std::unique_ptr<serdata_rmw> serdata_rmw_from_sample_unique(
   const struct ddsi_sertype * typecmn,
   enum ddsi_serdata_kind kind,
   const void * sample)
@@ -272,14 +296,135 @@ static struct ddsi_serdata * serdata_rmw_from_sample(
     const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(typecmn);
     auto d = std::make_unique<serdata_rmw>(type, kind);
     serialize_into_serdata_rmw(d.get(), sample);
-    return d.release();
+    return d;
   } catch (std::exception & e) {
     RMW_SET_ERROR_MSG(e.what());
     return nullptr;
   }
 }
 
-#ifdef DDS_HAS_SHM
+static struct ddsi_serdata * serdata_rmw_from_sample(
+  const struct ddsi_sertype * typecmn,
+  enum ddsi_serdata_kind kind,
+  const void * sample)
+{
+  return serdata_rmw_from_sample_unique(typecmn, kind, sample).release();
+}
+
+struct ddsi_serdata * serdata_rmw_from_serialized_message(
+  const struct ddsi_sertype * typecmn,
+  const void * raw, size_t size)
+{
+  ddsrt_iovec_t iov;
+  iov.iov_len = static_cast<ddsrt_iov_len_t>(size);
+  if (iov.iov_len != size) {
+    return nullptr;
+  }
+  iov.iov_base = const_cast<void *>(raw);
+  return ddsi_serdata_from_ser_iov(typecmn, SDK_DATA, 1, &iov, size);
+}
+
+#if CDDS_VERSION > CDDS_VERSION_0_10
+static struct ddsi_serdata *serdata_rmw_from_loaned_sample(
+  const struct ddsi_sertype *typecmn, enum ddsi_serdata_kind kind,
+  const char *sample, dds_loaned_sample_t *loaned_sample,
+  bool will_require_cdr)
+{
+  /*
+    type = the type of data being serialized
+    kind = the kind of data contained (key or normal)
+    sample = the raw sample made into the serdata
+    loaned_sample = the loaned buffer in use
+    will_require_cdr = whether we will need the CDR (or a highly likely to need it)
+  */
+  const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(typecmn);
+    
+  assert(sample == loaned_sample->sample_ptr);
+  assert(loaned_sample->metadata->sample_state == (kind == SDK_KEY ? DDS_LOANED_SAMPLE_STATE_RAW_KEY : DDS_LOANED_SAMPLE_STATE_RAW_DATA));
+  assert(loaned_sample->metadata->cdr_identifier == DDSI_RTPS_SAMPLE_NATIVE);
+  assert(loaned_sample->metadata->cdr_options == 0);
+
+  struct std::unique_ptr<serdata_rmw> d;
+  if (will_require_cdr)
+  {
+    // If serialization is/will be required, construct the serdata the normal way
+    d = serdata_rmw_from_sample_unique(type, kind, sample);
+  }
+  else
+  {
+    // If we know there is no neeed for the serialized representation (so only PSMX and "memcpy safe"),
+    // construct an empty serdata and stay away from the serializers
+    d = std::make_unique<serdata_rmw>(type, kind);
+  }
+  if (d == nullptr)
+    return nullptr;
+  else
+  {
+    // now owner of loan
+    d->loan = loaned_sample;
+    return d.release();
+  }
+}
+
+static bool loaned_sample_state_to_serdata_kind (dds_loaned_sample_state_t lss, enum ddsi_serdata_kind& kind)
+{
+  switch (lss)
+  {
+    case DDS_LOANED_SAMPLE_STATE_RAW_KEY:
+    case DDS_LOANED_SAMPLE_STATE_SERIALIZED_KEY:
+      kind = SDK_KEY;
+      return true;
+    case DDS_LOANED_SAMPLE_STATE_RAW_DATA:
+    case DDS_LOANED_SAMPLE_STATE_SERIALIZED_DATA:
+      kind = SDK_DATA;
+      return true;
+    case DDS_LOANED_SAMPLE_STATE_UNITIALIZED:
+      // invalid
+      return false;
+  }
+  // "impossible" value
+  return false;
+}
+
+static struct ddsi_serdata * serdata_rmw_from_psmx(
+  const struct ddsi_sertype * typecmn, dds_loaned_sample_t *loaned_sample)
+{
+  try {
+    const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(typecmn);
+    struct dds_psmx_metadata * const md = loaned_sample->metadata;
+    enum ddsi_serdata_kind kind;
+    if (!loaned_sample_state_to_serdata_kind (md->sample_state, kind))
+      return nullptr;
+
+    auto d = std::make_unique<serdata_rmw>(type, kind);
+    d->statusinfo = md->statusinfo;
+    d->timestamp.v = md->timestamp;
+    switch (md->sample_state)
+    {
+      case DDS_LOANED_SAMPLE_STATE_UNITIALIZED:
+        assert (0);
+        return nullptr;
+      case DDS_LOANED_SAMPLE_STATE_RAW_KEY:
+        // nothing to be done for key (yet)
+        break;
+      case DDS_LOANED_SAMPLE_STATE_RAW_DATA:
+        d->loan = loaned_sample;
+        dds_loaned_sample_ref (d->loan);
+        break;
+      case DDS_LOANED_SAMPLE_STATE_SERIALIZED_KEY:
+        // nothing to be done for key (yet)
+        break;
+      case DDS_LOANED_SAMPLE_STATE_SERIALIZED_DATA:
+        // ugly hack - drops `d`, makes a new one ... :(
+        return serdata_rmw_from_serialized_message(typecmn, loaned_sample->sample_ptr, md->sample_size);
+    }
+    return d.release();
+  } catch (std::exception & e) {
+    RMW_SET_ERROR_MSG(e.what());
+    return nullptr;
+  }
+}
+#elif defined DDS_HAS_SHM
 static struct ddsi_serdata * serdata_rmw_from_iox(
   const struct ddsi_sertype * typecmn,
   enum  ddsi_serdata_kind kind, void * sub, void * iox_buffer)
@@ -295,31 +440,13 @@ static struct ddsi_serdata * serdata_rmw_from_iox(
     return nullptr;
   }
 }
-#endif  // DDS_HAS_SHM
-
-struct ddsi_serdata * serdata_rmw_from_serialized_message(
-  const struct ddsi_sertype * typecmn,
-  const void * raw, size_t size)
-{
-  ddsrt_iovec_t iov;
-  iov.iov_len = static_cast<ddsrt_iov_len_t>(size);
-  if (iov.iov_len != size) {
-    return nullptr;
-  }
-  iov.iov_base = const_cast<void *>(raw);
-  return ddsi_serdata_from_ser_iov(typecmn, SDK_DATA, 1, &iov, size);
-}
+#endif
 
 static struct ddsi_serdata * serdata_rmw_to_untyped(const struct ddsi_serdata * dcmn)
 {
   auto d = static_cast<const serdata_rmw *>(dcmn);
-#if DDS_HAS_DDSI_SERTYPE
   auto d1 = new serdata_rmw(d->type, SDK_KEY);
   d1->type = nullptr;
-#else
-  auto d1 = new serdata_rmw(d->topic, SDK_KEY);
-  d1->topic = nullptr;
-#endif
   return d1;
 }
 
@@ -355,11 +482,7 @@ static bool serdata_rmw_to_sample(
     static_cast<void>(bufptr);    // unused
     static_cast<void>(buflim);    // unused
     auto d = static_cast<const serdata_rmw *>(dcmn);
-#if DDS_HAS_DDSI_SERTYPE
     const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(d->type);
-#else
-    const struct sertopic_rmw * type = static_cast<const struct sertopic_rmw *>(d->topic);
-#endif
     assert(bufptr == NULL);
     assert(buflim == NULL);
     if (d->kind != SDK_DATA) {
@@ -507,20 +630,19 @@ static const struct ddsi_serdata_ops serdata_rmw_ops = {
   serdata_rmw_free,
   serdata_rmw_print,
   serdata_rmw_get_keyhash
-#ifdef DDS_HAS_SHM
+#if CDDS_VERSION > CDDS_VERSION_0_10
+  , serdata_rmw_from_loaned_sample,
+  serdata_rmw_from_psmx
+#elif defined DDS_HAS_SHM
   , ddsi_serdata_iox_size,
   serdata_rmw_from_iox
-#endif  // DDS_HAS_SHM
+#endif
 };
 
 static void sertype_rmw_free(struct ddsi_sertype * tpcmn)
 {
   struct sertype_rmw * tp = static_cast<struct sertype_rmw *>(tpcmn);
-#if DDS_HAS_DDSI_SERTYPE
   ddsi_sertype_fini(tpcmn);
-#else
-  ddsi_sertopic_fini(tpcmn);
-#endif
   if (tp->type_support.type_support_) {
     if (using_introspection_c_typesupport(tp->type_support.typesupport_identifier_)) {
       delete static_cast<TypeSupport_c *>(tp->type_support.type_support_);
@@ -529,7 +651,7 @@ static void sertype_rmw_free(struct ddsi_sertype * tpcmn)
     }
     tp->type_support.type_support_ = NULL;
   }
-#ifdef HAS_DYNAMIC_TYPE
+#if DDS_HAS_TYPELIB
   ddsrt_free((void*)tp->type_information.data);
   ddsrt_free((void*)tp->type_mapping.data);
 #endif
@@ -647,7 +769,7 @@ bool sertype_serialize_into(
   return true;
 }
 
-#ifdef HAS_DYNAMIC_TYPE
+#if DDS_HAS_TYPELIB
 static ddsi_typeid_t * sertype_rmw_typeid (const struct ddsi_sertype * d, ddsi_typeid_kind_t kind)
 {
   assert(d);
@@ -704,19 +826,16 @@ static struct ddsi_sertype * sertype_rmw_derive_sertype (
 }
 #endif
 static const struct ddsi_sertype_ops sertype_rmw_ops = {
-#if DDS_HAS_DDSI_SERTYPE
   ddsi_sertype_v0,
   nullptr,
-#endif
   sertype_rmw_free,
   sertype_rmw_zero_samples,
   sertype_rmw_realloc_samples,
   sertype_rmw_free_samples,
   sertype_rmw_equal,
   sertype_rmw_hash
-#if DDS_HAS_DDSI_SERTYPE
-  /* not yet providing type discovery, assignability checking */
-#ifdef HAS_DYNAMIC_TYPE
+  /* type discovery, assignability checking only if cyclone has type library */
+#if DDS_HAS_TYPELIB
   ,
   sertype_rmw_typeid,
   sertype_rmw_typemap,
@@ -732,7 +851,6 @@ static const struct ddsi_sertype_ops sertype_rmw_ops = {
   ,
   sertype_get_serialized_size,
   sertype_serialize_into
-#endif
 };
 
 static std::string get_type_name(const char * type_support_identifier, void * type_support)
@@ -771,7 +889,8 @@ inline std::string create_type_name(const void * untyped_members)
   ss << "dds_::" << message_name << "_";
   return ss.str();
 }
-#ifdef HAS_DYNAMIC_TYPE
+
+#if DDS_HAS_TYPELIB
 dds_dynamic_type_descriptor_t get_dynamic_type_descriptor_prim(
   dds_dynamic_type_kind_t kind, const char *name, uint32_t num_bounds, const uint32_t *bounds, dds_dynamic_type_kind_t type)
 {
@@ -1027,7 +1146,7 @@ static bool construct_dds_dynamic_type(
 #endif
 void create_msg_dds_dynamic_type(const char * type_support_identifier, const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st)
 {
-#ifdef HAS_DYNAMIC_TYPE
+#if DDS_HAS_TYPELIB
   if (using_introspection_c_typesupport(type_support_identifier)) 
   {
     auto members = static_cast<const rosidl_typesupport_introspection_c__MessageMembers_s *>(untyped_members);
@@ -1068,7 +1187,7 @@ void create_msg_dds_dynamic_type(const char * type_support_identifier, const voi
 
 void create_req_dds_dynamic_type(const char * type_support_identifier, const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st)
 {
-#ifdef HAS_DYNAMIC_TYPE
+#if DDS_HAS_TYPELIB
   if (using_introspection_c_typesupport(type_support_identifier)) 
   {
     auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers_s *>(untyped_members);
@@ -1109,7 +1228,7 @@ void create_req_dds_dynamic_type(const char * type_support_identifier, const voi
 
 void create_res_dds_dynamic_type(const char * type_support_identifier, const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st)
 {
-#ifdef HAS_DYNAMIC_TYPE
+#if DDS_HAS_TYPELIB
   if (using_introspection_c_typesupport(type_support_identifier)) 
   {
     auto members = static_cast<const rosidl_typesupport_introspection_c__ServiceMembers_s *>(untyped_members);
@@ -1156,6 +1275,17 @@ struct sertype_rmw * create_sertype(
 {
   struct sertype_rmw * st = new struct sertype_rmw;
   std::string type_name = get_type_name(type_support_identifier, type_support);
+#if CDDS_VERSION > CDDS_VERSION_0_10
+  const uint32_t flags = 0;
+  dds_data_type_properties_t props = 0;
+  if (is_fixed_type) {
+    props |= DDS_DATA_TYPE_IS_MEMCPY_SAFE;
+  }
+  ddsi_sertype_init_props(
+    static_cast<struct ddsi_sertype *>(st),
+    type_name.c_str(), &sertype_rmw_ops, &serdata_rmw_ops,
+    sample_size, props, DDS_DATA_REPRESENTATION_FLAG_XCDR1, flags);
+#else
   uint32_t flags = DDSI_SERTYPE_FLAG_TOPICKIND_NO_KEY;
   if (is_fixed_type) {
     flags |= DDSI_SERTYPE_FLAG_FIXED_SIZE;
@@ -1169,7 +1299,8 @@ struct sertype_rmw * create_sertype(
   st->iox_size = sample_size;
 #else
   static_cast<void>(sample_size);
-#endif  // DDS_HAS_SHM
+#endif // DDS_HAS_SHM
+#endif
   st->type_support.typesupport_identifier_ = type_support_identifier;
   st->type_support.type_support_ = type_support;
   st->is_request_header = is_request_header;

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -730,7 +730,7 @@ uint32_t sertype_rmw_hash(const struct ddsi_sertype * tpcmn)
   return h1 ^ h2;
 }
 
-size_t sertype_get_serialized_size(const struct ddsi_sertype * d, const void * sample)
+static size_t sertype_get_serialized_size_impl(const struct ddsi_sertype * d, const void * sample)
 {
   const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(d);
   size_t serialized_size = 0;
@@ -750,16 +750,13 @@ size_t sertype_get_serialized_size(const struct ddsi_sertype * d, const void * s
   return serialized_size;
 }
 
-bool sertype_serialize_into(
+static bool sertype_serialize_into_impl(
   const struct ddsi_sertype * d,
   const void * sample,
-  void * dst_buffer,
-  size_t dst_size)
+  void * dst_buffer)
 {
   const struct sertype_rmw * type = static_cast<const struct sertype_rmw *>(d);
   try {
-    // ignore destination size (assuming that the destination buffer is resized before correctly)
-    static_cast<void>(dst_size);
     // ROS 2 doesn't support keys, so its all data (?)
     if (!type->is_request_header) {
       type->cdr_writer->serialize(dst_buffer, sample);
@@ -775,6 +772,53 @@ bool sertype_serialize_into(
   }
   return true;
 }
+
+#if CDDS_VERSION == CDDS_VERSION_0_10
+size_t sertype_get_serialized_size(const struct ddsi_sertype * d, const void * sample)
+{
+  return sertype_get_serialized_size_impl(d, sample);
+}
+
+bool sertype_serialize_into(
+  const struct ddsi_sertype * d,
+  const void * sample,
+  void * dst_buffer,
+  size_t dst_size)
+{
+  static_cast<void>(dst_size);
+  return sertype_serialize_into_impl(d, sample, dst_buffer);
+}
+#else
+dds_return_t sertype_get_serialized_size(
+  const struct ddsi_sertype * d,
+  enum ddsi_serdata_kind sdkind,
+  const void * sample,
+  size_t * size,
+  uint16_t * enc_identifier)
+{
+  static_cast<void>(sdkind);
+  size_t serialized_size = sertype_get_serialized_size_impl(d, sample);
+  // encoding identifier is always plain CDR for this serializer
+  *enc_identifier = (native_endian() == endian::little) ? DDSI_RTPS_CDR_LE : DDSI_RTPS_CDR_BE;
+  // Cyclone's including or excluding the CDR encoding header in the various situations is
+  // painfully inconsistent ...
+  assert (serialized_size >= 4);
+  *size = serialized_size - 4;
+  return DDS_RETCODE_OK;
+}
+
+bool sertype_serialize_into(
+  const struct ddsi_sertype * d,
+  enum ddsi_serdata_kind sdkind,
+  const void * sample,
+  void * dst_buffer,
+  size_t dst_size)
+{
+  static_cast<void>(sdkind);
+  static_cast<void>(dst_size);
+  return sertype_serialize_into_impl(d, sample, dst_buffer);
+}
+#endif
 
 #if DDS_HAS_TYPELIB
 static ddsi_typeid_t * sertype_rmw_typeid(const struct ddsi_sertype * d, ddsi_typeid_kind_t kind)

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -1067,6 +1067,9 @@ static bool construct_dds_dynamic_type(
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
         dynamic_type_add_member(dstruct, dds_ppant, member, DDS_DYNAMIC_CHAR8);
         break;
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WCHAR:
+        dynamic_type_add_member(dstruct, dds_ppant, member, DDS_DYNAMIC_CHAR16);
+        break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:
         dynamic_type_add_member(dstruct, dds_ppant, member, DDS_DYNAMIC_INT8);
         break;
@@ -1104,6 +1107,27 @@ static bool construct_dds_dynamic_type(
           } else {
             ddt = dds_dynamic_type_create(dds_ppant,
               get_dynamic_type_descriptor(DDS_DYNAMIC_STRING8, nullptr, 0, nullptr, {}));
+          }
+          if (!member->is_array_) {
+            ret = dds_dynamic_type_add_member(dstruct,
+            get_dynamic_member_descriptor(ddt, member->name_));
+            assert(ret == DDS_RETCODE_OK);
+          } else {
+            dynamic_type_add_array(dstruct, dds_ppant, member, ddt);
+          }
+
+          break;
+        }
+      case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_WSTRING:
+        {
+          dds_dynamic_type_t ddt;
+          if (member->string_upper_bound_) {
+            uint32_t string_size = static_cast<uint32_t>(member->string_upper_bound_);
+            ddt = dds_dynamic_type_create(dds_ppant,
+              get_dynamic_type_descriptor(DDS_DYNAMIC_STRING16, nullptr, 1, &string_size, {}));
+          } else {
+            ddt = dds_dynamic_type_create(dds_ppant,
+              get_dynamic_type_descriptor(DDS_DYNAMIC_STRING16, nullptr, 0, nullptr, {}));
           }
           if (!member->is_array_) {
             ret = dds_dynamic_type_add_member(dstruct,

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -104,15 +104,15 @@ struct ddsi_serdata * serdata_rmw_from_serialized_message(
   const void * raw, size_t size);
 
 void create_msg_dds_dynamic_type(
-  const char* type_support_identifier,
+  const char * type_support_identifier,
   const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
 
 void create_req_dds_dynamic_type(
-  const char* type_support_identifier,
+  const char * type_support_identifier,
   const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
 
 void create_res_dds_dynamic_type(
-  const char* type_support_identifier,
+  const char * type_support_identifier,
   const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
 
 #endif  // SERDATA_HPP_

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -53,6 +53,8 @@ struct sertype_rmw : ddsi_sertype
   std::unique_ptr<const rmw_cyclonedds_cpp::BaseCDRWriter> cdr_writer;
   bool is_fixed;
   std::mutex serialize_lock;
+  struct dds_type_meta_ser type_information;
+  struct dds_type_meta_ser type_mapping;
 };
 
 class serdata_rmw : public ddsi_serdata
@@ -97,10 +99,22 @@ struct sertype_rmw * create_sertype(
   void * type_support, bool is_request_header,
   std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type_support,
   const uint32_t sample_size = 0U,
-  const bool is_fixed_type = false);
+  const bool is_fixed_type = false
+);
 
 struct ddsi_serdata * serdata_rmw_from_serialized_message(
   const struct ddsi_sertype * typecmn,
   const void * raw, size_t size);
 
+void create_msg_dds_dynamic_type(
+  const char* type_support_identifier,
+  const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
+
+void create_req_dds_dynamic_type(
+  const char* type_support_identifier,
+  const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
+
+void create_res_dds_dynamic_type(
+  const char* type_support_identifier,
+  const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
 #endif  // SERDATA_HPP_

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -22,17 +22,12 @@
 #include "bytewise.hpp"
 #include "dds/dds.h"
 #include "dds/ddsi/ddsi_serdata.h"
-#ifdef DDS_HAS_SHM
+#include "cdds_version.hpp"
+
+#if CDDS_VERSION == CDDS_VERSION_0_10 && defined DDS_HAS_SHM
 extern "C" {
 #include "dds/ddsi/ddsi_shm_transport.h"
 }
-#endif  // DDS_HAS_SHM
-
-#if !DDS_HAS_DDSI_SERTYPE
-#define ddsi_sertype ddsi_sertopic
-#define ddsi_sertype_ops ddsi_sertopic_ops
-#define sertype_rmw sertopic_rmw
-#define sertype_rmw_ops sertopic_rmw_ops
 #endif
 
 namespace rmw_cyclonedds_cpp
@@ -53,8 +48,10 @@ struct sertype_rmw : ddsi_sertype
   std::unique_ptr<const rmw_cyclonedds_cpp::BaseCDRWriter> cdr_writer;
   bool is_fixed;
   std::mutex serialize_lock;
+#if DDS_HAS_TYPELIB
   struct dds_type_meta_ser type_information;
   struct dds_type_meta_ser type_mapping;
+#endif
 };
 
 class serdata_rmw : public ddsi_serdata
@@ -117,4 +114,5 @@ void create_req_dds_dynamic_type(
 void create_res_dds_dynamic_type(
   const char* type_support_identifier,
   const void * untyped_members, dds_entity_t dds_ppant, struct sertype_rmw * st);
+
 #endif  // SERDATA_HPP_


### PR DESCRIPTION
This PR takes the type definition/discovery work from #445, and adds the changes needed to match the work done on Cyclone DDS's `master` branch since that PR was made. The big change here is the refactoring that moved the Iceoryx support into a plugin.

All old configs and code not using any special features should work unchanged, but the RMW layer does its own serialization and needs to support loans, and these necessitates some changes.

It also means that Iceoryx is no longer needed as build dependency, but I think it is important that the RMW layer continues to work unchanged with 0.10.x, at least until there is a tag/branch for the next release of Cyclone that incorporates all those changes.

This is a draft PR because I haven't gotten around to checking all combinations of not-loan/loan, serialized/not-serialized, simple/complex types, etc. etc. etc. I do think it worthwhile to make it easy to find for everyone else who is curious and to reduce the risk of double work, in case someone else also decides to give it a try.

Fixes #525 