### PR TITLE
suppress leak sanitizer for expected leak

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -192,8 +192,8 @@ struct Cdds
 };
 
 #if defined(__has_feature)
-#if __has_feature(address_sanitizer) // for clang
-#define __SANITIZE_ADDRESS__         // GCC already sets this
+#if __has_feature(address_sanitizer)   // for clang
+#define __SANITIZE_ADDRESS__           // GCC already sets this
 #endif
 #endif
 

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -200,6 +200,8 @@ struct Cdds
 #if defined(__SANITIZE_ADDRESS__)
 #include <sanitizer/lsan_interface.h>
 #endif
+
+
 /* Use construct-on-first-use for the global state rather than a plain global variable to
    prevent its destructor from running prior to last use by some other component in the
    system.  E.g., some rclcpp tests (at the time of this commit) drop a guard condition in

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -191,6 +191,15 @@ struct Cdds
   {}
 };
 
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer) // for clang
+#define __SANITIZE_ADDRESS__         // GCC already sets this
+#endif
+#endif
+
+#if defined(__SANITIZE_ADDRESS__)
+#include <sanitizer/lsan_interface.h>
+#endif
 /* Use construct-on-first-use for the global state rather than a plain global variable to
    prevent its destructor from running prior to last use by some other component in the
    system.  E.g., some rclcpp tests (at the time of this commit) drop a guard condition in
@@ -209,6 +218,9 @@ struct Cdds
 static Cdds & gcdds()
 {
   static Cdds * x = new Cdds();
+#if defined(__SANITIZE_ADDRESS__)
+  __lsan_ignore_object(x);
+#endif
   return *x;
 }
 


### PR DESCRIPTION
this memory is expected to leak, but will create lots of leak warning for any exe which depends on it. rmw_cyclonedds is load through dlopen, such leak can't suppressed by runtime suppression https://github.com/google/sanitizers/issues/89, better to annotate it 