### PR TITLE
Reset the error before setting a new one.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1811,6 +1811,7 @@ extern "C" rmw_ret_t rmw_serialize(
     auto size = writer->get_serialized_size(ros_message);
     rmw_ret_t ret = rmw_serialized_message_resize(serialized_message, size);
     if (RMW_RET_OK != ret) {
+      rmw_reset_error();
       RMW_SET_ERROR_MSG("rmw_serialize: failed to allocate space for message");
       return ret;
     }


### PR DESCRIPTION
rmw_serialized_message_resize() is defined as
rcutils_uint8_array_resize(), which means if it fails, the error message it sets are from rcutils.  This seems confusing, so on failure reset the error and set a new one.  This also avoids an "overwritten" error message.