### PR TITLE
Add CPU-based fallback support for `rosidl::Buffer` type

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -52,6 +52,7 @@ find_package(rmw REQUIRED)
 find_package(rmw_dds_common REQUIRED)
 find_package(rmw_security_common REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
+find_package(rosidl_buffer REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
 
@@ -87,6 +88,7 @@ target_link_libraries(rmw_cyclonedds_cpp PUBLIC
 
 target_link_libraries(rmw_cyclonedds_cpp PRIVATE
   CycloneDDS::ddsc
+  rosidl_buffer::rosidl_buffer
   rcutils::rcutils
   rcpputils::rcpputils
   rmw_dds_common::rmw_dds_common_library

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -16,6 +16,7 @@
 
   <depend>cyclonedds</depend>
   <depend>iceoryx_binding_c</depend>
+  <depend>rosidl_buffer</depend>
   <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <depend>rmw</depend>

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
@@ -176,6 +176,9 @@ ROSIDLC_StructValueType::ROSIDLC_StructValueType(
     } else if (member_impl.array_size_ != 0 && !member_impl.is_upper_bound_) {
       member_value_type = make_value_type<ArrayValueType>(
         element_value_type, member_impl.array_size_);
+    } else if (member_impl.is_rosidl_buffer_) {
+      member_value_type = make_value_type<ROSIDLC_BufferSpanSequenceValueType>(
+        element_value_type);
     } else if (member_impl.size_function) {
       member_value_type = make_value_type<CallbackSpanSequenceValueType>(
         element_value_type, member_impl.size_function, member_impl.get_const_function);
@@ -222,6 +225,8 @@ ROSIDLCPP_StructValueType::ROSIDLCPP_StructValueType(
     } else if (member_impl.array_size_ != 0 && !member_impl.is_upper_bound_) {
       member_value_type = make_value_type<ArrayValueType>(
         element_value_type, member_impl.array_size_);
+    } else if (member_impl.is_rosidl_buffer_) {
+      member_value_type = make_value_type<CppBufferSpanSequenceValueType>(element_value_type);
     } else if (ROSIDL_TypeKind(member_impl.type_id_) == ROSIDL_TypeKind::BOOLEAN) {
       member_value_type = make_value_type<BoolVectorValueType>();
     } else {

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -553,6 +553,7 @@ class ROSIDLC_BufferSpanSequenceValueType : public SpanSequenceValueType
     size_t size;
     size_t capacity;
     bool is_rosidl_buffer;
+    bool owns_rosidl_buffer;
   };
 
 public:

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -29,6 +29,7 @@
 #include "rosidl_typesupport_introspection_c/identifier.h"
 #include "rosidl_typesupport_introspection_c/message_introspection.h"
 #include "rosidl_typesupport_introspection_c/service_introspection.h"
+#include "rosidl_buffer/buffer.hpp"
 #include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 #include "rosidl_typesupport_introspection_cpp/identifier.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
@@ -512,6 +513,75 @@ auto AnyValueType::apply(UnaryFunction f)
       unreachable();
   }
 }
+
+/// For C++ introspection: field is directly rosidl::Buffer<uint8_t>.
+/// For serialization of non-CPU buffers, copies data to an internal CPU cache.
+class CppBufferSpanSequenceValueType : public SpanSequenceValueType
+{
+  const AnyValueType * m_element_value_type;
+  mutable std::vector<uint8_t> cpu_cache_;
+
+public:
+  explicit CppBufferSpanSequenceValueType(const AnyValueType * evt)
+  : m_element_value_type(evt) {}
+  size_t sizeof_type() const override {return sizeof(rosidl::Buffer<uint8_t>);}
+  const AnyValueType * element_value_type() const override {return m_element_value_type;}
+  size_t sequence_size(const void * ptr) const override
+  {
+    return reinterpret_cast<const rosidl::Buffer<uint8_t> *>(ptr)->size();
+  }
+  const void * sequence_contents(const void * ptr) const override
+  {
+    auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(ptr);
+    if (buf->size() == 0) {return nullptr;}
+    if (buf->get_backend_type() == "cpu") {return buf->data();}
+    cpu_cache_ = buf->to_vector();
+    return cpu_cache_.data();
+  }
+};
+
+/// For C introspection: field is rosidl_runtime_c__uint8__Sequence with is_rosidl_buffer flag.
+/// When is_rosidl_buffer is true, seq->data points to a Buffer<uint8_t>*.
+class ROSIDLC_BufferSpanSequenceValueType : public SpanSequenceValueType
+{
+  const AnyValueType * m_element_value_type;
+  mutable std::vector<uint8_t> cpu_cache_;
+
+  struct ROSIDLC_BufferSequenceObject
+  {
+    void * data;
+    size_t size;
+    size_t capacity;
+    bool is_rosidl_buffer;
+  };
+
+public:
+  explicit ROSIDLC_BufferSpanSequenceValueType(const AnyValueType * evt)
+  : m_element_value_type(evt) {}
+  size_t sizeof_type() const override {return sizeof(ROSIDLC_BufferSequenceObject);}
+  const AnyValueType * element_value_type() const override {return m_element_value_type;}
+  size_t sequence_size(const void * ptr) const override
+  {
+    auto * seq = static_cast<const ROSIDLC_BufferSequenceObject *>(ptr);
+    if (seq->is_rosidl_buffer) {
+      auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(seq->data);
+      return buf->size();
+    }
+    return seq->size;
+  }
+  const void * sequence_contents(const void * ptr) const override
+  {
+    auto * seq = static_cast<const ROSIDLC_BufferSequenceObject *>(ptr);
+    if (seq->is_rosidl_buffer) {
+      auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(seq->data);
+      if (buf->size() == 0) {return nullptr;}
+      if (buf->get_backend_type() == "cpu") {return buf->data();}
+      cpu_cache_ = buf->to_vector();
+      return cpu_cache_.data();
+    }
+    return seq->data;
+  }
+};
 
 }  // namespace rmw_cyclonedds_cpp
 #endif  // TYPESUPPORT2_HPP_

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -515,11 +515,10 @@ auto AnyValueType::apply(UnaryFunction f)
 }
 
 /// For C++ introspection: field is directly rosidl::Buffer<uint8_t>.
-/// For serialization of non-CPU buffers, copies data to an internal CPU cache.
+/// For serialization of non-CPU buffers, copies data to a thread-local CPU cache.
 class CppBufferSpanSequenceValueType : public SpanSequenceValueType
 {
   const AnyValueType * m_element_value_type;
-  mutable std::vector<uint8_t> cpu_cache_;
 
 public:
   explicit CppBufferSpanSequenceValueType(const AnyValueType * evt)
@@ -535,8 +534,9 @@ public:
     auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(ptr);
     if (buf->size() == 0) {return nullptr;}
     if (buf->get_backend_type() == "cpu") {return buf->data();}
-    cpu_cache_ = buf->to_vector();
-    return cpu_cache_.data();
+    thread_local std::vector<uint8_t> cpu_cache;
+    cpu_cache = buf->to_vector();
+    return cpu_cache.data();
   }
 };
 
@@ -545,7 +545,6 @@ public:
 class ROSIDLC_BufferSpanSequenceValueType : public SpanSequenceValueType
 {
   const AnyValueType * m_element_value_type;
-  mutable std::vector<uint8_t> cpu_cache_;
 
   struct ROSIDLC_BufferSequenceObject
   {
@@ -577,8 +576,9 @@ public:
       auto * buf = reinterpret_cast<const rosidl::Buffer<uint8_t> *>(seq->data);
       if (buf->size() == 0) {return nullptr;}
       if (buf->get_backend_type() == "cpu") {return buf->data();}
-      cpu_cache_ = buf->to_vector();
-      return cpu_cache_.data();
+      thread_local std::vector<uint8_t> cpu_cache;
+      cpu_cache = buf->to_vector();
+      return cpu_cache.data();
     }
     return seq->data;
   }

--- a/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
@@ -19,10 +19,12 @@
 #include <cassert>
 #include <functional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 #include "TypeSupport.hpp"
 #include "macros.hpp"
+#include "rosidl_buffer/buffer.hpp"
 #include "rmw/error_handling.h"
 #include "rosidl_typesupport_introspection_cpp/field_types.hpp"
 #include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
@@ -276,7 +278,35 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_BYTE:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_UINT8:
-        deserialize_field<uint8_t>(member, field, deser);
+        if (member->is_rosidl_buffer_ && member->is_array_ &&
+          !(member->array_size_ && !member->is_upper_bound_))
+        {
+          if constexpr (std::is_same_v<MembersType,
+            rosidl_typesupport_introspection_cpp::MessageMembers>)
+          {
+            auto & buffer = *reinterpret_cast<rosidl::Buffer<uint8_t> *>(field);
+            int32_t dsize = 0;
+            deser >> dsize;
+            buffer.resize(dsize);
+            if (dsize > 0) {deser.deserializeA(buffer.data(), dsize);}
+          } else {
+            auto * seq = reinterpret_cast<rosidl_runtime_c__uint8__Sequence *>(field);
+            int32_t dsize = 0;
+            deser >> dsize;
+            if (seq->is_rosidl_buffer && seq->data) {
+              auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(seq->data);
+              buf->resize(dsize);
+              if (dsize > 0) {deser.deserializeA(buf->data(), dsize);}
+            } else {
+              if (!rosidl_runtime_c__uint8__Sequence__init(seq, dsize)) {
+                throw std::runtime_error("unable to initialize uint8 sequence");
+              }
+              if (dsize > 0) {deser.deserializeA(seq->data, dsize);}
+            }
+          }
+        } else {
+          deserialize_field<uint8_t>(member, field, deser);
+        }
         break;
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_CHAR:
       case ::rosidl_typesupport_introspection_cpp::ROS_TYPE_INT8:

--- a/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport_impl.hpp
@@ -285,14 +285,12 @@ bool TypeSupport<MembersType>::deserializeROSmessage(
             rosidl_typesupport_introspection_cpp::MessageMembers>)
           {
             auto & buffer = *reinterpret_cast<rosidl::Buffer<uint8_t> *>(field);
-            int32_t dsize = 0;
-            deser >> dsize;
+            const uint32_t dsize = deser.deserialize_len(1);
             buffer.resize(dsize);
             if (dsize > 0) {deser.deserializeA(buffer.data(), dsize);}
           } else {
             auto * seq = reinterpret_cast<rosidl_runtime_c__uint8__Sequence *>(field);
-            int32_t dsize = 0;
-            deser >> dsize;
+            const uint32_t dsize = deser.deserialize_len(1);
             if (seq->is_rosidl_buffer && seq->data) {
               auto * buf = reinterpret_cast<rosidl::Buffer<uint8_t> *>(seq->data);
               buf->resize(dsize);


### PR DESCRIPTION
## Description

This pull request adds `rosidl::Buffer` CPU-based fallback support to `rmw_cyclonedds_cpp`.
Since CycloneDDS uses introspection typesupport instead of FastRTPS typesupport that has full support of the buffer descriptor-based endpoint-aware serialization, it gracefully falls back (by converting) to CPU-based buffer/sequence when non-CPU backends are encountered.

This pull request consists of the following key changes:

- **`TypeSupport2`** (`TypeSupport2.hpp`, `TypeSupport2.cpp`): Routes `uint8[]` fields marked `is_rosidl_buffer_` to the new `ROSIDLC_BufferSpanSequenceValueType` (C introspection) and `CppBufferSpanSequenceValueType` (C++ introspection) that convert non-CPU buffers to CPU-based types. 
- **`TypeSupport_impl`** (`TypeSupport_impl.hpp`): Extends the `uint8` deserialization path to detect `is_rosidl_buffer_` fields and deserialize directly into `rosidl::Buffer<uint8_t>` (C++ introspection) or into the `rosidl::Buffer<uint8_t>*` held by the C sequence (C introspection).

### Is this user-facing behavior change?

This pull request does not change existing CycloneDDS behavior. It ensures that messages with `uint8[]` fields can be correctly serialized and deserialized by CycloneDDS using CPU-backed data. Non-CPU buffer backends will trigger a CPU fallback conversion maintaining functional correctness.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

Yes. Claude (claude-4.6-opus) via Cursor was used to assist with creating an initial prototype version of the changes contained in this PR.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

This PR is part of the broader ROS 2 native buffer feature introduced in this [post](https://discourse.openrobotics.org/t/working-prototype-of-native-buffers-accelerated-memory-transport/52399).
