### PR TITLE
UNSUPPORTED is not error, so should not set the error string.

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3239,7 +3239,6 @@ extern "C" rmw_ret_t rmw_subscription_set_content_filter(
   static_cast<void>(subscription);
   static_cast<void>(options);
 
-  RMW_SET_ERROR_MSG("rmw_subscription_set_content_filter: unimplemented");
   return RMW_RET_UNSUPPORTED;
 }
 
@@ -3252,7 +3251,6 @@ extern "C" rmw_ret_t rmw_subscription_get_content_filter(
   static_cast<void>(allocator);
   static_cast<void>(options);
 
-  RMW_SET_ERROR_MSG("rmw_subscription_get_content_filter: unimplemented");
   return RMW_RET_UNSUPPORTED;
 }
 


### PR DESCRIPTION
## Description

This error messages actually fail some tests, because tests expect that no error strings are set.
e.g `rcl_action` from https://ci.ros2.org/job/ci_linux/28060/#showFailuresLink

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Part of https://github.com/ros2/rmw_cyclonedds/pull/550

### Is this user-facing behavior change?

Not really. but if the application rely on the error string in rcutils, that would be empty now.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
