### PR TITLE
Added tracepoint to rmw_take_loan_int

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3625,7 +3625,7 @@ static rmw_ret_t rmw_take_loan_int(
             RMW_SET_ERROR_MSG("Failed to deserialize sample from shared memory buffer");
             ddsi_serdata_unref(d);
             *taken = false;
-            return RMW_RET_ERROR;
+            goto take_done_err;
           }
         } else if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
           *loaned_message = d->iox_chunk;
@@ -3633,7 +3633,7 @@ static rmw_ret_t rmw_take_loan_int(
           RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
           ddsi_serdata_unref(d);
           *taken = false;
-          return RMW_RET_ERROR;
+          goto take_done_err;
         }
         *taken = true;
         // doesn't allocate, but initialise the allocator to free the chunk later when the loan
@@ -3645,7 +3645,7 @@ static rmw_ret_t rmw_take_loan_int(
         // `rmw_return_loaned_message_from_subscription()` is called
         d->iox_chunk = nullptr;
         ddsi_serdata_unref(d);
-        return RMW_RET_OK;
+        goto take_done;
       } else if (d->type->iox_size > 0U) {
         auto sample_ptr = init_and_alloc_sample(cdds_subscription, d->type->iox_size, true);
         RET_NULL_X(sample_ptr, return RMW_RET_ERROR);
@@ -3653,18 +3653,33 @@ static rmw_ret_t rmw_take_loan_int(
         *loaned_message = sample_ptr;
         ddsi_serdata_unref(d);
         *taken = true;
-        return RMW_RET_OK;
+        goto take_done;
       } else {
         RMW_SET_ERROR_MSG("Data nor loan is available to take");
         ddsi_serdata_unref(d);
         *taken = false;
-        return RMW_RET_ERROR;
+        goto take_done_err;
       }
     }
     ddsi_serdata_unref(d);
   }
   *taken = false;
+take_done:
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(*loaned_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
   return RMW_RET_OK;
+take_done_err:
+  TRACETOOLS_TRACEPOINT(
+    rmw_take,
+    static_cast<const void *>(subscription),
+    static_cast<const void *>(*loaned_message),
+    (message_info ? message_info->source_timestamp : 0LL),
+    *taken);
+  return RMW_RET_ERROR;
 #else
   static_cast<void>(subscription);
   static_cast<void>(loaned_message);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3671,7 +3671,7 @@ take_done:
     static_cast<const void *>(*loaned_message),
     (message_info ? message_info->source_timestamp : 0LL),
     *taken);
-  return (*taken) ? RMW_RET_OK ? RMW_RET_ERROR;
+  return (*taken) ? RMW_RET_OK : RMW_RET_ERROR;
 #else
   static_cast<void>(subscription);
   static_cast<void>(loaned_message);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3625,7 +3625,7 @@ static rmw_ret_t rmw_take_loan_int(
             RMW_SET_ERROR_MSG("Failed to deserialize sample from shared memory buffer");
             ddsi_serdata_unref(d);
             *taken = false;
-            goto take_done_err;
+            goto take_done;
           }
         } else if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
           *loaned_message = d->iox_chunk;
@@ -3633,7 +3633,7 @@ static rmw_ret_t rmw_take_loan_int(
           RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
           ddsi_serdata_unref(d);
           *taken = false;
-          goto take_done_err;
+          goto take_done;
         }
         *taken = true;
         // doesn't allocate, but initialise the allocator to free the chunk later when the loan
@@ -3658,7 +3658,7 @@ static rmw_ret_t rmw_take_loan_int(
         RMW_SET_ERROR_MSG("Data nor loan is available to take");
         ddsi_serdata_unref(d);
         *taken = false;
-        goto take_done_err;
+        goto take_done;
       }
     }
     ddsi_serdata_unref(d);
@@ -3671,15 +3671,7 @@ take_done:
     static_cast<const void *>(*loaned_message),
     (message_info ? message_info->source_timestamp : 0LL),
     *taken);
-  return RMW_RET_OK;
-take_done_err:
-  TRACETOOLS_TRACEPOINT(
-    rmw_take,
-    static_cast<const void *>(subscription),
-    static_cast<const void *>(*loaned_message),
-    (message_info ? message_info->source_timestamp : 0LL),
-    *taken);
-  return RMW_RET_ERROR;
+  return (*taken) ? RMW_RET_OK ? RMW_RET_ERROR;
 #else
   static_cast<void>(subscription);
   static_cast<void>(loaned_message);


### PR DESCRIPTION
## Description

It's difficult to fully trace a ROS2 system using zero-copy, because the message loaning functions don't invoke the rmw_take tracepoint, like the other rmw_take variants. This corrects for that.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
