### PR TITLE
Ai perf improvement / Fix perf regressions from key support

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -16,9 +16,11 @@ cmake_minimum_required(VERSION 3.20)
 
 project(rmw_cyclonedds_cpp)
 
-# Default to C++17
+option(USE_NEW_CDR_IMPL "Use the new CDRSerializer/CDRDeserializer instead of the old CDRWriter/CDRReader" ON)
+
+# Default to C++20
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
+  set(CMAKE_CXX_STANDARD 20)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
@@ -79,6 +81,9 @@ add_library(rmw_cyclonedds_cpp
   src/u16string.cpp
   src/demangle.cpp
   src/Serialization.cpp
+  src/SizeTypeSupport.cpp
+  src/SerTypeSupport.cpp
+  src/DeserTypeSupport.cpp
   src/TypeSupport2.cpp
   src/type_name.cpp
   src/dyntype.cpp
@@ -124,6 +129,7 @@ target_compile_definitions(${PROJECT_NAME}
     RMW_VERSION_MAJOR=${rmw_VERSION_MAJOR}
     RMW_VERSION_MINOR=${rmw_VERSION_MINOR}
     RMW_VERSION_PATCH=${rmw_VERSION_PATCH}
+    $<$<BOOL:${USE_NEW_CDR_IMPL}>:USE_NEW_CDR_IMPL>
 )
 
 ament_export_targets(export_rmw_cyclonedds_cpp)
@@ -135,6 +141,82 @@ register_rmw_implementation(
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_google_benchmark REQUIRED)
+  find_package(std_msgs REQUIRED)
+  find_package(visualization_msgs REQUIRED)
+  find_package(rcl_interfaces REQUIRED)
+  find_package(example_interfaces REQUIRED)
+  find_package(sensor_msgs REQUIRED)
+  find_package(test_msgs REQUIRED)
+  find_package(iceoryx_binding_c REQUIRED)
+
+  # Static library with serialization sources shared across all test targets.
+  add_library(ts_test_support STATIC
+    src/SizeTypeSupport.cpp
+    src/SerTypeSupport.cpp
+    src/DeserTypeSupport.cpp
+    src/TypeSupport2.cpp
+    src/Serialization.cpp)
+  target_include_directories(ts_test_support PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/src
+    ${CMAKE_CURRENT_SOURCE_DIR}/test
+    ${CMAKE_BINARY_DIR}/src)
+  target_link_libraries(ts_test_support PUBLIC
+    CycloneDDS::ddsc
+    iceoryx_binding_c::iceoryx_binding_c
+    rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
+    rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c)
+
+  # -- std_msgs + visualization_msgs tests ------------------------------------
+  ament_add_gtest(test_ts_std_msgs test/test_std_msgs.cpp)
+  target_link_libraries(test_ts_std_msgs
+    ts_test_support
+    ${std_msgs_LIBRARIES}
+    ${visualization_msgs_LIBRARIES})
+  ament_target_dependencies(test_ts_std_msgs std_msgs visualization_msgs)
+
+  # -- rcl_interfaces tests ---------------------------------------------------
+  ament_add_gtest(test_ts_rcl_interfaces test/test_rcl_interfaces.cpp)
+  target_link_libraries(test_ts_rcl_interfaces
+    ts_test_support
+    ${rcl_interfaces_LIBRARIES})
+  ament_target_dependencies(test_ts_rcl_interfaces rcl_interfaces)
+
+  # -- wstring (example_interfaces) tests -------------------------------------
+  ament_add_gtest(test_ts_wstring test/test_wstring.cpp)
+  target_link_libraries(test_ts_wstring
+    ts_test_support
+    ${example_interfaces_LIBRARIES})
+  ament_target_dependencies(test_ts_wstring example_interfaces)
+
+  # -- keyed message tests (test_msgs) ----------------------------------------
+  ament_add_gtest(test_ts_keyed_msgs test/test_keyed_msgs.cpp)
+  target_link_libraries(test_ts_keyed_msgs
+    ts_test_support
+    ${test_msgs_LIBRARIES})
+  ament_target_dependencies(test_ts_keyed_msgs test_msgs)
+
+  # -- test_msgs serialization tests ------------------------------------------
+  ament_add_gtest(test_ts_test_msgs test/test_test_msgs.cpp)
+  target_link_libraries(test_ts_test_msgs
+    ts_test_support
+    ${test_msgs_LIBRARIES}
+    ${rmw_dds_common_LIBRARIES})
+  ament_target_dependencies(test_ts_test_msgs test_msgs rmw_dds_common)
+
+  # -- benchmark --------------------------------------------------------------
+  ament_add_google_benchmark(benchmark_size_computation
+    test/benchmark_size_computation.cpp)
+  target_link_libraries(benchmark_size_computation
+    ts_test_support
+    rmw_cyclonedds_cpp
+    ${std_msgs_LIBRARIES}
+    ${visualization_msgs_LIBRARIES}
+    ${sensor_msgs_LIBRARIES})
+  ament_target_dependencies(benchmark_size_computation
+    std_msgs visualization_msgs sensor_msgs)
 endif()
 
 ament_package()

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -27,8 +27,12 @@
   <depend>rosidl_typesupport_introspection_cpp</depend>
   <depend>tracetools</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_google_benchmark</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>std_msgs</test_depend>
+  <test_depend>visualization_msgs</test_depend>
 
   <member_of_group>rmw_implementation_packages</member_of_group>
 

--- a/rmw_cyclonedds_cpp/src/BaseCDRReader.hpp
+++ b/rmw_cyclonedds_cpp/src/BaseCDRReader.hpp
@@ -1,0 +1,50 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef BASE_CDR_READER_HPP_
+#define BASE_CDR_READER_HPP_
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "SizeTypeSupport.hpp"  // for MessageMembersVariant, SampleOrKey, SampleOrRequest
+
+namespace rmw_cyclonedds_cpp
+{
+
+class BaseCDRReader
+{
+public:
+  virtual void deserialize(
+    void * dest, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const = 0;
+  virtual void extractkey(
+    std::vector<std::byte> & dest, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const = 0;
+  virtual void extractkey_be(
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const = 0;
+  virtual size_t print(
+    char * dst, size_t dstsize, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const = 0;
+
+  virtual ~BaseCDRReader() = default;
+};
+
+std::unique_ptr<BaseCDRReader> make_cdr_reader(
+  MessageMembersVariant members,
+  SampleOrRequest variant);
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // BASE_CDR_READER_HPP_

--- a/rmw_cyclonedds_cpp/src/BaseCDRReader.hpp
+++ b/rmw_cyclonedds_cpp/src/BaseCDRReader.hpp
@@ -46,5 +46,9 @@ std::unique_ptr<BaseCDRReader> make_cdr_reader(
   MessageMembersVariant members,
   SampleOrRequest variant);
 
+std::unique_ptr<BaseCDRReader> make_cdr_reader_old(
+  MessageMembersVariant members,
+  SampleOrRequest variant);
+
 }  // namespace rmw_cyclonedds_cpp
 #endif  // BASE_CDR_READER_HPP_

--- a/rmw_cyclonedds_cpp/src/BaseCDRWriter.hpp
+++ b/rmw_cyclonedds_cpp/src/BaseCDRWriter.hpp
@@ -1,0 +1,45 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef BASE_CDR_WRITER_HPP_
+#define BASE_CDR_WRITER_HPP_
+
+#include <cstddef>
+#include <memory>
+
+#include "TypeSupport2.hpp"
+
+namespace rmw_cyclonedds_cpp
+{
+
+class BaseCDRWriter
+{
+public:
+  virtual size_t get_serialized_size(const void * data, SampleOrKey what) const = 0;
+  virtual size_t get_serialized_size_estimate(const void * data, SampleOrKey what) const = 0;
+
+  // includes 4 bytes encoding header
+  virtual size_t get_min_serialized_size(SampleOrKey what) const = 0;
+  // includes 4 bytes encoding header, SIZE_MAX if unbounded
+  virtual size_t get_max_serialized_size(SampleOrKey what) const = 0;
+
+  virtual void serialize(void * dest, const void * data, SampleOrKey what) const = 0;
+  virtual TypeGenerator type_generator() const = 0;
+  virtual ~BaseCDRWriter() = default;
+};
+
+std::unique_ptr<BaseCDRWriter> make_cdr_writer(
+  MessageMembersVariant members, SampleOrRequest variant);
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // BASE_CDR_WRITER_HPP_

--- a/rmw_cyclonedds_cpp/src/BaseCDRWriter.hpp
+++ b/rmw_cyclonedds_cpp/src/BaseCDRWriter.hpp
@@ -41,5 +41,8 @@ public:
 std::unique_ptr<BaseCDRWriter> make_cdr_writer(
   MessageMembersVariant members, SampleOrRequest variant);
 
+std::unique_ptr<BaseCDRWriter> make_cdr_writer_old(
+  MessageMembersVariant members, SampleOrRequest variant);
+
 }  // namespace rmw_cyclonedds_cpp
 #endif  // BASE_CDR_WRITER_HPP_

--- a/rmw_cyclonedds_cpp/src/DeserTypeSupport.cpp
+++ b/rmw_cyclonedds_cpp/src/DeserTypeSupport.cpp
@@ -560,23 +560,28 @@ struct WriteVecCursor
 // Deser read helpers
 // ---------------------------------------------------------------------------
 
+template<bool Bswap>
 static void deser_read(DeserializeCursor & c, void * dst,
   const DeserAnyType & t, SampleOrKey what);
+template<bool Bswap>
 static void deser_read_struct(DeserializeCursor & c, void * dst,
   const DeserStruct & s, SampleOrKey what);
+template<bool Bswap>
 static void deser_read_many(DeserializeCursor & c, void * base,
   size_t native_stride, size_t count, const DeserAnyType & elem, SampleOrKey what);
 
+template<bool Bswap>
 static void deser_read_many(
   DeserializeCursor & c, void * base,
   size_t native_stride, size_t count, const DeserAnyType & elem, SampleOrKey what)
 {
   for (size_t i = 0; i < count; ++i) {
     void * p = static_cast<char *>(base) + i * native_stride;
-    deser_read(c, p, elem, what);
+    deser_read<Bswap>(c, p, elem, what);
   }
 }
 
+template<bool Bswap>
 static void deser_read(
   DeserializeCursor & c, void * dst,
   const DeserAnyType & t, SampleOrKey what)
@@ -587,7 +592,7 @@ static void deser_read(
 
       if constexpr (std::is_same_v<T, SerPrimitive>) {
         c.align(v.cdr_align);
-        if (!v.needs_bswap) {
+        if constexpr (!Bswap) {
           c.get_bytes(dst, v.native_size);
         } else {
           const unsigned char * src = c.advance(v.cdr_size);
@@ -604,6 +609,9 @@ static void deser_read(
         uint32_t len;
         c.align(4);
         c.get_bytes(&len, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &len); len = swapped;
+        }
         if (len == 0) {
           throw std::runtime_error("CDR deserialization: size-0 string");
         }
@@ -617,12 +625,15 @@ static void deser_read(
         uint32_t byte_len;
         c.align(4);
         c.get_bytes(&byte_len, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &byte_len); byte_len = swapped;
+        }
         if (byte_len % 2) {
           throw std::runtime_error("CDR deserialization: odd wstring byte count");
         }
         const unsigned char * str_bytes = c.advance(byte_len);
         size_t n_chars = byte_len / 2;
-        if (host_needs_bswap()) {
+        if constexpr (Bswap) {
           std::vector<char16_t> tmp(n_chars);
           for (size_t i = 0; i < n_chars; ++i) {
             uint16_t ch;
@@ -638,6 +649,9 @@ static void deser_read(
         uint32_t count;
         c.align(4);
         c.get_bytes(&count, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &count); count = swapped;
+        }
         if (!v.resize(dst, count)) { throw std::bad_alloc(); }
         for (uint32_t i = 0; i < count; ++i) {
           const unsigned char * b = c.advance(1);
@@ -648,6 +662,9 @@ static void deser_read(
         uint32_t count;
         c.align(4);
         c.get_bytes(&count, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &count); count = swapped;
+        }
         v.resize(dst, count);
         for (uint32_t i = 0; i < count; ++i) {
           const unsigned char * b = c.advance(1);
@@ -659,13 +676,16 @@ static void deser_read(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           c.get_bytes(dst, v.count * v.native_elem_stride);
         } else {
-          deser_read_many(c, dst, v.native_elem_stride, v.count, *v.element, what);
+          deser_read_many<Bswap>(c, dst, v.native_elem_stride, v.count, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, DeserCSequence>) {
         uint32_t count;
         c.align(4);
         c.get_bytes(&count, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &count); count = swapped;
+        }
         if (!v.resize(dst, count)) { throw std::bad_alloc(); }
         if (count == 0) {
           return;
@@ -674,13 +694,16 @@ static void deser_read(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           c.get_bytes(base, count * v.native_elem_stride);
         } else {
-          deser_read_many(c, base, v.native_elem_stride, count, *v.element, what);
+          deser_read_many<Bswap>(c, base, v.native_elem_stride, count, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, DeserCppSequence>) {
         uint32_t count;
         c.align(4);
         c.get_bytes(&count, 4);
+        if constexpr (Bswap) {
+          uint32_t swapped; bswap_n<4>(&swapped, &count); count = swapped;
+        }
         v.resize(dst, count);
         if (count == 0) {
           return;
@@ -689,15 +712,16 @@ static void deser_read(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           c.get_bytes(base, count * v.native_elem_stride);
         } else {
-          deser_read_many(c, base, v.native_elem_stride, count, *v.element, what);
+          deser_read_many<Bswap>(c, base, v.native_elem_stride, count, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, DeserStruct>) {
-        deser_read_struct(c, dst, v, what);
+        deser_read_struct<Bswap>(c, dst, v, what);
       }
     }, t);
 }
 
+template<bool Bswap>
 static void deser_read_struct(
   DeserializeCursor & c, void * dst,
   const DeserStruct & s, SampleOrKey what)
@@ -710,7 +734,7 @@ static void deser_read_struct(
   for (const auto & member : s.members) {
     if (all_fields || member.is_key) {
       void * field = static_cast<char *>(dst) + member.native_offset;
-      deser_read(c, field, *member.type, what);
+      deser_read<Bswap>(c, field, *member.type, what);
     }
   }
 }
@@ -924,7 +948,11 @@ void CDRDeserializer::deserialize(
   }
 
   if (what == SampleOrKey::Sample || m_root.has_keys) {
-    deser_read_struct(c, dst, m_root, what);
+    if (bswap_src) {
+      deser_read_struct<true>(c, dst, m_root, what);
+    } else {
+      deser_read_struct<false>(c, dst, m_root, what);
+    }
   }
   c.rebase(-4);
 }

--- a/rmw_cyclonedds_cpp/src/DeserTypeSupport.cpp
+++ b/rmw_cyclonedds_cpp/src/DeserTypeSupport.cpp
@@ -1,0 +1,990 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "DeserTypeSupport.hpp"
+#include "SerDesInternals.hpp"
+
+#include <bit>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "rosidl_runtime_c/string_functions.h"
+#include "rosidl_runtime_c/u16string_functions.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+
+#include "TypeSupport2.hpp"   // for cdds_request_wrapper_t
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// String assign helpers (write-side)
+// ---------------------------------------------------------------------------
+
+static void c_string_assign(void * s, const char * src, size_t n)
+{
+  rosidl_runtime_c__String__assignn(
+    static_cast<rosidl_runtime_c__String *>(s), src, n);
+}
+
+static void c_wstring_assign(void * s, const char16_t * src, size_t n)
+{
+  rosidl_runtime_c__U16String__assignn(
+    static_cast<rosidl_runtime_c__U16String *>(s),
+    reinterpret_cast<const uint16_t *>(src), n);
+}
+
+static void cpp_string_assign(void * s, const char * src, size_t n)
+{
+  *static_cast<std::string *>(s) = std::string(src, n);
+}
+
+static void cpp_wstring_assign(void * s, const char16_t * src, size_t n)
+{
+  *static_cast<std::u16string *>(s) = std::u16string(src, n);
+}
+
+// ---------------------------------------------------------------------------
+// Sequence resize + mut_contents helpers
+// ---------------------------------------------------------------------------
+
+// C rosidl sequence layout: {T* data, size_t size, size_t capacity}
+struct RosidlCSeqLayout { void * data; size_t size; size_t capacity; };
+
+static void * c_seq_mut_contents(void * seq)
+{
+  return static_cast<RosidlCSeqLayout *>(seq)->data;
+}
+
+// std::vector<T> layout: { T* _M_start, T* _M_finish, T* _M_end_of_storage }
+static void * cpp_vec_mut_contents(void * seq)
+{
+  return *static_cast<void **>(seq);  // first field is T* begin
+}
+
+// ---------------------------------------------------------------------------
+// Static resize/assign helpers for raw-function-pointer Deser types
+// ---------------------------------------------------------------------------
+
+// C bool seq assign: write into data[idx]
+static void c_bool_seq_assign(void * seq, size_t idx, uint8_t val)
+{
+  auto * layout = static_cast<RosidlCSeqLayout *>(seq);
+  static_cast<uint8_t *>(layout->data)[idx] = val;
+}
+
+// ---------------------------------------------------------------------------
+// Deser element builders — forward declarations
+// ---------------------------------------------------------------------------
+
+static DeserStruct make_deser_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  DeserTypeStorage & store);
+static DeserStruct make_deser_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  DeserTypeStorage & store);
+static void deser_stamp_trivial_struct(DeserStruct & s);
+
+// ---------------------------------------------------------------------------
+// alloc_deser helper
+// ---------------------------------------------------------------------------
+
+template<typename T>
+static const DeserAnyType * alloc_deser(DeserTypeStorage & store, T value)
+{
+  assert(store.nodes.size() < store.nodes.capacity());
+  store.nodes.emplace_back(std::move(value));
+  return &store.nodes.back();
+}
+
+// ---------------------------------------------------------------------------
+// Deser stamp pass (mirrors ser_stamp_trivial but for DeserAnyType)
+// ---------------------------------------------------------------------------
+
+static TrivialArray deser_trivial_of(const DeserAnyType & t);
+static size_t deser_fixed_cdr_stride(const DeserAnyType & t);
+static void deser_stamp_trivial(DeserAnyType & t);
+
+static TrivialArray deser_trivial_of(const DeserAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> TrivialArray {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (
+        std::is_same_v<T, SerPrimitive> ||
+        std::is_same_v<T, DeserStruct> ||
+        std::is_same_v<T, DeserArray> ||
+        std::is_same_v<T, DeserCSequence> ||
+        std::is_same_v<T, DeserCppSequence>)
+      {
+        return v.trivial_at_align;
+      }
+      return TrivialArray{};
+    }, t);
+}
+
+static size_t deser_fixed_cdr_stride(const DeserAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SerPrimitive>) {
+        return v.cdr_size;
+      } else if constexpr (std::is_same_v<T, DeserStruct>) {
+        return v.trivial_at_align[0] ? v.native_size : 0;
+      } else if constexpr (std::is_same_v<T, DeserArray>) {
+        return (v.fixed_cdr_stride > 0) ? v.count * v.fixed_cdr_stride : 0;
+      }
+      return 0;
+    }, t);
+}
+
+static bool deser_struct_trivial_at(const DeserStruct & s, size_t a)
+{
+  if (host_needs_bswap()) {
+    return false;
+  }
+  size_t cursor = a;
+  for (const auto & member : s.members) {
+    const TrivialArray & ta = deser_trivial_of(*member.type);
+    if (!ta[cursor % kSerMaxAlign]) {
+      return false;
+    }
+    size_t member_cdr_size = std::visit(
+      [](const auto & v) -> size_t {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, SerPrimitive>) {
+          return v.cdr_size;
+        } else if constexpr (std::is_same_v<T, DeserStruct>) {
+          return v.native_size;
+        } else if constexpr (std::is_same_v<T, DeserArray>) {
+          return (v.fixed_cdr_stride > 0) ? v.count * v.fixed_cdr_stride : 0;
+        }
+        return 0;
+      }, *member.type);
+    if (member_cdr_size == 0) {
+      return false;
+    }
+    cursor += member_cdr_size;
+  }
+  return (cursor - a) == s.native_size;
+}
+
+static void deser_stamp_trivial(DeserAnyType & t)
+{
+  std::visit(
+    [](auto & v) {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, DeserStruct>) {
+        deser_stamp_trivial_struct(v);
+      } else if constexpr (std::is_same_v<T, DeserArray>) {
+        v.fixed_cdr_stride = deser_fixed_cdr_stride(*v.element);
+        for (size_t a = 0; a < kSerMaxAlign; ++a) {
+          if (v.fixed_cdr_stride == 0) {
+            v.trivial_at_align[a] = false;
+          } else {
+            const TrivialArray & et = deser_trivial_of(*v.element);
+            v.trivial_at_align[a] =
+              et[a % kSerMaxAlign] &&
+              et[(a + v.fixed_cdr_stride) % kSerMaxAlign];
+          }
+        }
+      } else if constexpr (
+        std::is_same_v<T, DeserCSequence> ||
+        std::is_same_v<T, DeserCppSequence>)
+      {
+        v.fixed_cdr_stride = deser_fixed_cdr_stride(*v.element);
+        for (size_t a = 0; a < kSerMaxAlign; ++a) {
+          if (v.fixed_cdr_stride == 0) {
+            v.trivial_at_align[a] = false;
+          } else {
+            const TrivialArray & et = deser_trivial_of(*v.element);
+            v.trivial_at_align[a] =
+              et[a] &&
+              et[(a + v.fixed_cdr_stride) % kSerMaxAlign];
+          }
+        }
+      }
+    }, t);
+}
+
+static void deser_stamp_trivial_struct(DeserStruct & s)
+{
+  for (size_t a = 0; a < kSerMaxAlign; ++a) {
+    s.trivial_at_align[a] = deser_struct_trivial_at(s, a);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Deser element builders — C
+// ---------------------------------------------------------------------------
+
+static const DeserAnyType * make_deser_element_c(
+  const rosidl_typesupport_introspection_c__MessageMember & m,
+  DeserTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+    case ROSIDL_TypeKind::DOUBLE:
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_deser(store, make_ser_primitive(ROSIDL_TypeKind(m.type_id_)));
+    case ROSIDL_TypeKind::STRING:
+      return alloc_deser(store, DeserString{c_string_assign});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_deser(store, DeserWString{c_wstring_assign});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_deser_struct_c(
+        static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
+          m.members_->data), store);
+      return alloc_deser(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_deser_element_c: unknown type kind");
+  }
+}
+
+static DeserStruct make_deser_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  DeserTypeStorage & store)
+{
+  DeserStruct st;
+  st.has_keys = false;
+  st.native_size = impl->size_of_;
+
+  struct LocalMember { const DeserAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+    const ROSIDL_TypeKind kind = ROSIDL_TypeKind(m.type_id_);
+
+    const DeserAnyType * elem = make_deser_element_c(m, store);
+
+    const DeserAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      // Fixed array
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<DeserStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(rosidl_runtime_c__String);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(rosidl_runtime_c__U16String);
+      } else {
+        nat_stride = c_elem_native_stride(kind);
+      }
+      member_type = alloc_deser(store, DeserArray{elem, m.array_size_, nat_stride});
+    } else {
+      // Dynamic sequence — C rosidl {data*, size, capacity}
+      if (kind == ROSIDL_TypeKind::BOOLEAN) {
+        member_type = alloc_deser(store, DeserCBoolVector{m.resize_function, c_bool_seq_assign});
+      } else {
+        size_t nat_stride;
+        if (kind == ROSIDL_TypeKind::MESSAGE) {
+          nat_stride = std::get<DeserStruct>(*elem).native_size;
+        } else if (kind == ROSIDL_TypeKind::STRING) {
+          nat_stride = sizeof(rosidl_runtime_c__String);
+        } else if (kind == ROSIDL_TypeKind::WSTRING) {
+          nat_stride = sizeof(rosidl_runtime_c__U16String);
+        } else {
+          nat_stride = c_elem_native_stride(kind);
+        }
+        member_type = alloc_deser(store, DeserCSequence{
+          elem, nat_stride, 0, {}, m.resize_function, c_seq_mut_contents});
+      }
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(DeserMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const DeserMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+// ---------------------------------------------------------------------------
+// Deser element builders — C++
+// ---------------------------------------------------------------------------
+
+static const DeserAnyType * make_deser_element_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMember & m,
+  DeserTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+    case ROSIDL_TypeKind::DOUBLE:
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_deser(store, make_ser_primitive(ROSIDL_TypeKind(m.type_id_)));
+    case ROSIDL_TypeKind::STRING:
+      return alloc_deser(store, DeserString{cpp_string_assign});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_deser(store, DeserWString{cpp_wstring_assign});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_deser_struct_cpp(
+        static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+          m.members_->data), store);
+      return alloc_deser(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_deser_element_cpp: unknown type kind");
+  }
+}
+
+static DeserStruct make_deser_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  DeserTypeStorage & store)
+{
+  DeserStruct st;
+  st.has_keys = false;
+  st.native_size = impl->size_of_;
+
+  struct LocalMember { const DeserAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+    const ROSIDL_TypeKind kind = ROSIDL_TypeKind(m.type_id_);
+
+    const DeserAnyType * elem = make_deser_element_cpp(m, store);
+
+    const DeserAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      // Fixed array
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<DeserStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(std::string);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(std::u16string);
+      } else {
+        nat_stride = native_size_of_kind(kind);
+      }
+      member_type = alloc_deser(store, DeserArray{elem, m.array_size_, nat_stride});
+    } else {
+      if (kind == ROSIDL_TypeKind::BOOLEAN) {
+        // C++ vector<bool>: resize_function(void*,size_t)->void, assign_function(void*,size_t,const void*)
+        member_type = alloc_deser(store, DeserCppBoolVector{m.resize_function, m.assign_function});
+      } else {
+        size_t nat_stride;
+        if (kind == ROSIDL_TypeKind::MESSAGE) {
+          nat_stride = std::get<DeserStruct>(*elem).native_size;
+        } else if (kind == ROSIDL_TypeKind::STRING) {
+          nat_stride = sizeof(std::string);
+        } else if (kind == ROSIDL_TypeKind::WSTRING) {
+          nat_stride = sizeof(std::u16string);
+        } else {
+          nat_stride = native_size_of_kind(kind);
+        }
+        member_type = alloc_deser(store, DeserCppSequence{
+          elem, nat_stride, 0, {}, m.resize_function, cpp_vec_mut_contents});
+      }
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(DeserMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const DeserMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+// ---------------------------------------------------------------------------
+// Public builder
+// ---------------------------------------------------------------------------
+
+std::pair<DeserStruct, DeserTypeStorage> make_deser_struct(MessageMembersVariant members)
+{
+  DeserTypeStorage store;
+  // Count pass: determine how many nodes and members we need, then reserve.
+  auto counts = std::visit(
+    [](const auto * m) { return count_type_tree(m); }, members);
+  store.nodes.reserve(counts.nodes);
+  store.all_members.reserve(counts.members);
+
+  auto root = std::visit(
+    [&store](const auto * m) -> DeserStruct {
+      using T = std::decay_t<decltype(*m)>;
+      if constexpr (std::is_same_v<T, MetaMessage<TypeGenerator::ROSIDL_C>>) {
+        return make_deser_struct_c(m, store);
+      } else {
+        return make_deser_struct_cpp(m, store);
+      }
+    }, members);
+  // Stamp pass: iterate all nodes in allocation order (children before parents).
+  for (auto & node : store.nodes) {
+    deser_stamp_trivial(node);
+  }
+  deser_stamp_trivial_struct(root);
+  return {std::move(root), std::move(store)};
+}
+
+// ---------------------------------------------------------------------------
+// DeserializeCursor — inline read cursor, no virtual dispatch
+// ---------------------------------------------------------------------------
+
+struct DeserializeCursor
+{
+  const unsigned char * pos;
+  const unsigned char * origin;
+  const unsigned char * end;
+
+  DeserializeCursor(const void * data, size_t size)
+  : pos(static_cast<const unsigned char *>(data)),
+    origin(static_cast<const unsigned char *>(data)),
+    end(static_cast<const unsigned char *>(data) + size) {}
+
+  size_t offset() const {return static_cast<size_t>(pos - origin);}
+
+  void rebase(ptrdiff_t delta) {origin += delta;}
+
+  void align(size_t n)
+  {
+    size_t rem = offset() & (n - 1);
+    if (rem) {
+      pos += n - rem;
+    }
+  }
+
+  const unsigned char * advance(size_t n)
+  {
+    if (static_cast<size_t>(end - pos) < n) {
+      throw std::runtime_error("CDR deserialization: truncated input");
+    }
+    const unsigned char * p = pos;
+    pos += n;
+    return p;
+  }
+
+  void get_bytes(void * dst, size_t n)
+  {
+    std::memcpy(dst, advance(n), n);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// WriteVecCursor — output cursor for extractkey (appends to std::vector<std::byte>)
+// ---------------------------------------------------------------------------
+
+struct WriteVecCursor
+{
+  std::vector<std::byte> & buf;
+  size_t origin_offset = 0;
+
+  explicit WriteVecCursor(std::vector<std::byte> & b)
+  : buf(b), origin_offset(0) {}
+
+  size_t offset() const {return buf.size() - origin_offset;}
+
+  void rebase(ptrdiff_t delta) {origin_offset = static_cast<size_t>(
+    static_cast<ptrdiff_t>(origin_offset) + delta);}
+
+  void align(size_t n)
+  {
+    size_t rem = offset() & (n - 1);
+    if (rem) {
+      buf.insert(buf.end(), n - rem, std::byte{0});
+    }
+  }
+
+  void put_bytes(const void * src, size_t n)
+  {
+    const auto * p = static_cast<const std::byte *>(src);
+    buf.insert(buf.end(), p, p + n);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Deser read helpers
+// ---------------------------------------------------------------------------
+
+static void deser_read(DeserializeCursor & c, void * dst,
+  const DeserAnyType & t, SampleOrKey what);
+static void deser_read_struct(DeserializeCursor & c, void * dst,
+  const DeserStruct & s, SampleOrKey what);
+static void deser_read_many(DeserializeCursor & c, void * base,
+  size_t native_stride, size_t count, const DeserAnyType & elem, SampleOrKey what);
+
+static void deser_read_many(
+  DeserializeCursor & c, void * base,
+  size_t native_stride, size_t count, const DeserAnyType & elem, SampleOrKey what)
+{
+  for (size_t i = 0; i < count; ++i) {
+    void * p = static_cast<char *>(base) + i * native_stride;
+    deser_read(c, p, elem, what);
+  }
+}
+
+static void deser_read(
+  DeserializeCursor & c, void * dst,
+  const DeserAnyType & t, SampleOrKey what)
+{
+  std::visit(
+    [&](const auto & v) {
+      using T = std::decay_t<decltype(v)>;
+
+      if constexpr (std::is_same_v<T, SerPrimitive>) {
+        c.align(v.cdr_align);
+        if (!v.needs_bswap) {
+          c.get_bytes(dst, v.native_size);
+        } else {
+          const unsigned char * src = c.advance(v.cdr_size);
+          switch (v.cdr_size) {
+            case 1: std::memcpy(dst, src, 1); break;
+            case 2: bswap_n<2>(dst, src); break;
+            case 4: bswap_n<4>(dst, src); break;
+            case 8: bswap_n<8>(dst, src); break;
+            default: break;
+          }
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserString>) {
+        uint32_t len;
+        c.align(4);
+        c.get_bytes(&len, 4);
+        if (len == 0) {
+          throw std::runtime_error("CDR deserialization: size-0 string");
+        }
+        const unsigned char * str_bytes = c.advance(len);
+        if (str_bytes[len - 1] != '\0') {
+          throw std::runtime_error("CDR deserialization: unterminated string");
+        }
+        v.assign(dst, reinterpret_cast<const char *>(str_bytes), len - 1);
+
+      } else if constexpr (std::is_same_v<T, DeserWString>) {
+        uint32_t byte_len;
+        c.align(4);
+        c.get_bytes(&byte_len, 4);
+        if (byte_len % 2) {
+          throw std::runtime_error("CDR deserialization: odd wstring byte count");
+        }
+        const unsigned char * str_bytes = c.advance(byte_len);
+        size_t n_chars = byte_len / 2;
+        if (host_needs_bswap()) {
+          std::vector<char16_t> tmp(n_chars);
+          for (size_t i = 0; i < n_chars; ++i) {
+            uint16_t ch;
+            bswap_n<2>(&ch, str_bytes + i * 2);
+            tmp[i] = static_cast<char16_t>(ch);
+          }
+          v.assign(dst, tmp.data(), n_chars);
+        } else {
+          v.assign(dst, reinterpret_cast<const char16_t *>(str_bytes), n_chars);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserCBoolVector>) {
+        uint32_t count;
+        c.align(4);
+        c.get_bytes(&count, 4);
+        if (!v.resize(dst, count)) { throw std::bad_alloc(); }
+        for (uint32_t i = 0; i < count; ++i) {
+          const unsigned char * b = c.advance(1);
+          v.assign_byte(dst, i, *b);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserCppBoolVector>) {
+        uint32_t count;
+        c.align(4);
+        c.get_bytes(&count, 4);
+        v.resize(dst, count);
+        for (uint32_t i = 0; i < count; ++i) {
+          const unsigned char * b = c.advance(1);
+          bool val = (*b != 0);
+          v.assign_fn(dst, i, &val);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserArray>) {
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          c.get_bytes(dst, v.count * v.native_elem_stride);
+        } else {
+          deser_read_many(c, dst, v.native_elem_stride, v.count, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserCSequence>) {
+        uint32_t count;
+        c.align(4);
+        c.get_bytes(&count, 4);
+        if (!v.resize(dst, count)) { throw std::bad_alloc(); }
+        if (count == 0) {
+          return;
+        }
+        void * base = v.mut_contents(dst);
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          c.get_bytes(base, count * v.native_elem_stride);
+        } else {
+          deser_read_many(c, base, v.native_elem_stride, count, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserCppSequence>) {
+        uint32_t count;
+        c.align(4);
+        c.get_bytes(&count, 4);
+        v.resize(dst, count);
+        if (count == 0) {
+          return;
+        }
+        void * base = v.mut_contents(dst);
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          c.get_bytes(base, count * v.native_elem_stride);
+        } else {
+          deser_read_many(c, base, v.native_elem_stride, count, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserStruct>) {
+        deser_read_struct(c, dst, v, what);
+      }
+    }, t);
+}
+
+static void deser_read_struct(
+  DeserializeCursor & c, void * dst,
+  const DeserStruct & s, SampleOrKey what)
+{
+  if (what == SampleOrKey::Sample && s.trivial_at_align[c.offset() % kSerMaxAlign]) {
+    c.get_bytes(dst, s.native_size);
+    return;
+  }
+  bool all_fields = (what == SampleOrKey::Sample || !s.has_keys);
+  for (const auto & member : s.members) {
+    if (all_fields || member.is_key) {
+      void * field = static_cast<char *>(dst) + member.native_offset;
+      deser_read(c, field, *member.type, what);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// extractkey helpers — scan CDR src, write key fields to WriteVecCursor dst
+// ---------------------------------------------------------------------------
+
+enum class ExtractKeyMode2 { Sample, Key, Skip };
+
+static void extract_key_write(DeserializeCursor & src, WriteVecCursor & dst,
+  const DeserAnyType & t, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst);
+static void extract_key_write_struct(DeserializeCursor & src, WriteVecCursor & dst,
+  const DeserStruct & s, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst);
+
+static void extract_key_write_primitive(
+  DeserializeCursor & src, WriteVecCursor & dst,
+  const SerPrimitive & p, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst)
+{
+  src.align(p.cdr_align);
+  const unsigned char * data = src.advance(p.cdr_size);
+  if (mode == ExtractKeyMode2::Skip) {
+    return;
+  }
+  dst.align(p.cdr_align);
+  if (bswap_src == bswap_dst) {
+    dst.put_bytes(data, p.cdr_size);
+  } else {
+    unsigned char tmp[8];
+    switch (p.cdr_size) {
+      case 1: std::memcpy(tmp, data, 1); break;
+      case 2: bswap_n<2>(tmp, data); break;
+      case 4: bswap_n<4>(tmp, data); break;
+      case 8: bswap_n<8>(tmp, data); break;
+      default: std::memcpy(tmp, data, p.cdr_size); break;
+    }
+    dst.put_bytes(tmp, p.cdr_size);
+  }
+}
+
+static void extract_key_write_u32(
+  DeserializeCursor & src, WriteVecCursor & dst,
+  uint32_t * out_val, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst)
+{
+  src.align(4);
+  const unsigned char * data = src.advance(4);
+  uint32_t val;
+  std::memcpy(&val, data, 4);
+  if (bswap_src) {
+    uint32_t swapped;
+    bswap_n<4>(&swapped, &val);
+    val = swapped;
+  }
+  *out_val = val;
+  if (mode == ExtractKeyMode2::Skip) {
+    return;
+  }
+  dst.align(4);
+  if (!bswap_dst) {
+    dst.put_bytes(&val, 4);
+  } else {
+    uint32_t be_val;
+    bswap_n<4>(&be_val, &val);
+    dst.put_bytes(&be_val, 4);
+  }
+}
+
+static void extract_key_write_many(
+  DeserializeCursor & src, WriteVecCursor & dst,
+  size_t count, const DeserAnyType & elem,
+  ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst)
+{
+  for (size_t i = 0; i < count; ++i) {
+    extract_key_write(src, dst, elem, mode, bswap_src, bswap_dst);
+  }
+}
+
+static void extract_key_write(
+  DeserializeCursor & src, WriteVecCursor & dst,
+  const DeserAnyType & t, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst)
+{
+  std::visit(
+    [&](const auto & v) {
+      using T = std::decay_t<decltype(v)>;
+
+      if constexpr (std::is_same_v<T, SerPrimitive>) {
+        extract_key_write_primitive(src, dst, v, mode, bswap_src, bswap_dst);
+
+      } else if constexpr (
+        std::is_same_v<T, DeserString> || std::is_same_v<T, DeserWString>)
+      {
+        uint32_t len;
+        src.align(4);
+        src.get_bytes(&len, 4);
+        if constexpr (std::is_same_v<T, DeserString>) {
+          const unsigned char * str_bytes = src.advance(len);
+          if (mode != ExtractKeyMode2::Skip) {
+            dst.align(4);
+            uint32_t dlen = len;
+            if (bswap_dst) { bswap_n<4>(&dlen, &dlen); }
+            dst.put_bytes(&dlen, 4);
+            dst.put_bytes(str_bytes, len);
+          }
+        } else {
+          const unsigned char * str_bytes = src.advance(len);
+          if (mode != ExtractKeyMode2::Skip) {
+            dst.align(4);
+            uint32_t dlen = len;
+            if (bswap_dst) { bswap_n<4>(&dlen, &dlen); }
+            dst.put_bytes(&dlen, 4);
+            if (bswap_src == bswap_dst) {
+              dst.put_bytes(str_bytes, len);
+            } else {
+              for (uint32_t i = 0; i < len; i += 2) {
+                unsigned char tmp[2];
+                bswap_n<2>(tmp, str_bytes + i);
+                dst.put_bytes(tmp, 2);
+              }
+            }
+          }
+        }
+
+      } else if constexpr (
+        std::is_same_v<T, DeserCBoolVector> ||
+        std::is_same_v<T, DeserCppBoolVector>)
+      {
+        uint32_t count;
+        src.align(4);
+        src.get_bytes(&count, 4);
+        const unsigned char * data = src.advance(count);
+        if (mode != ExtractKeyMode2::Skip) {
+          dst.align(4);
+          uint32_t dcount = count;
+          if (bswap_dst) { bswap_n<4>(&dcount, &dcount); }
+          dst.put_bytes(&dcount, 4);
+          dst.put_bytes(data, count);
+        }
+
+      } else if constexpr (std::is_same_v<T, DeserArray>) {
+        extract_key_write_many(src, dst, v.count, *v.element, mode, bswap_src, bswap_dst);
+
+      } else if constexpr (
+        std::is_same_v<T, DeserCSequence> ||
+        std::is_same_v<T, DeserCppSequence>)
+      {
+        uint32_t count;
+        extract_key_write_u32(src, dst, &count, mode, bswap_src, bswap_dst);
+        extract_key_write_many(src, dst, count, *v.element, mode, bswap_src, bswap_dst);
+
+      } else if constexpr (std::is_same_v<T, DeserStruct>) {
+        extract_key_write_struct(src, dst, v, mode, bswap_src, bswap_dst);
+      }
+    }, t);
+}
+
+static void extract_key_write_struct(
+  DeserializeCursor & src, WriteVecCursor & dst,
+  const DeserStruct & s, ExtractKeyMode2 mode, bool bswap_src, bool bswap_dst)
+{
+  bool all_key = !s.has_keys;
+  for (const auto & member : s.members) {
+    ExtractKeyMode2 m = mode;
+    if (mode == ExtractKeyMode2::Sample) {
+      m = (member.is_key || all_key) ? ExtractKeyMode2::Key : ExtractKeyMode2::Skip;
+    } else if (mode == ExtractKeyMode2::Key) {
+      if (!member.is_key && !all_key) {
+        m = ExtractKeyMode2::Skip;
+      }
+    }
+    extract_key_write(src, dst, *member.type, m, bswap_src, bswap_dst);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CDRDeserializer implementation
+// ---------------------------------------------------------------------------
+
+CDRDeserializer::CDRDeserializer(MessageMembersVariant members, SampleOrRequest variant)
+: m_storage{},
+  m_root{},
+  m_variant(variant)
+{
+  auto [root, storage] = make_deser_struct(members);
+  m_storage = std::move(storage);
+  m_root = std::move(root);
+}
+
+void CDRDeserializer::deserialize(
+  void * dst, const void * cdr, size_t cdrsize, SampleOrKey what) const
+{
+  if (what == SampleOrKey::Key && !m_root.has_keys) {
+    return;
+  }
+  DeserializeCursor c(cdr, cdrsize);
+  const unsigned char * hdr = c.advance(4);
+  c.rebase(+4);
+  if (hdr[0] != 0 || hdr[1] > 1) {
+    throw std::runtime_error("CDR deserialization: unrecognized header");
+  }
+  const bool bswap_src = (hdr[1] == 0) == (std::endian::native == std::endian::little);
+
+  if (what == SampleOrKey::Sample && m_variant == SampleOrRequest::Request) {
+    auto * req = static_cast<cdds_request_wrapper_t *>(dst);
+    c.get_bytes(&req->header.guid, sizeof(req->header.guid));
+    c.get_bytes(&req->header.seq,  sizeof(req->header.seq));
+    if (bswap_src) {
+      bswap_n<8>(&req->header.guid, &req->header.guid);
+      bswap_n<8>(&req->header.seq,  &req->header.seq);
+    }
+    dst = req->data;
+  }
+
+  if (what == SampleOrKey::Sample || m_root.has_keys) {
+    deser_read_struct(c, dst, m_root, what);
+  }
+  c.rebase(-4);
+}
+
+void CDRDeserializer::extractkey(
+  std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+  SampleOrKey what) const
+{
+  extractkey_impl(dst, cdr, cdrsize, what, false);
+}
+
+void CDRDeserializer::extractkey_be(
+  std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+  SampleOrKey what) const
+{
+  extractkey_impl(dst, cdr, cdrsize, what, true);
+}
+
+void CDRDeserializer::extractkey_impl(
+  std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+  SampleOrKey what, bool output_be) const
+{
+  if (!m_root.has_keys) {
+    return;
+  }
+  DeserializeCursor src(cdr, cdrsize);
+  const unsigned char * hdr = src.advance(4);
+  src.rebase(+4);
+  if (hdr[0] != 0 || hdr[1] > 1) {
+    throw std::runtime_error("CDR deserialization: unrecognized header");
+  }
+  const bool bswap_src = (hdr[1] == 0) == (std::endian::native == std::endian::little);
+  const bool bswap_dst = output_be;
+
+  const unsigned char rtps_hdr[4] = {0,
+    static_cast<unsigned char>(output_be ? 0 : 1), 0, 0};
+  dst.insert(dst.end(),
+    reinterpret_cast<const std::byte *>(rtps_hdr),
+    reinterpret_cast<const std::byte *>(rtps_hdr) + 4);
+
+  WriteVecCursor wc(dst);
+  wc.rebase(+4);
+
+  if (what == SampleOrKey::Sample && m_variant == SampleOrRequest::Request) {
+    src.advance(16);
+  }
+
+  const ExtractKeyMode2 kmode =
+    (what == SampleOrKey::Key) ? ExtractKeyMode2::Key : ExtractKeyMode2::Sample;
+  extract_key_write_struct(src, wc, m_root, kmode, bswap_src, bswap_dst);
+
+  wc.rebase(-4);
+  src.rebase(-4);
+}
+
+size_t CDRDeserializer::print(
+  char * dst, size_t dstsize, const void *, size_t, SampleOrKey) const
+{
+  if (dstsize > 0) { dst[0] = '\0'; }
+  return 0;
+}
+
+}  // namespace rmw_cyclonedds_cpp

--- a/rmw_cyclonedds_cpp/src/DeserTypeSupport.hpp
+++ b/rmw_cyclonedds_cpp/src/DeserTypeSupport.hpp
@@ -1,0 +1,171 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef DESER_TYPE_SUPPORT_HPP_
+#define DESER_TYPE_SUPPORT_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "SizeTypeSupport.hpp"   // MessageMembersVariant, SampleOrKey, SampleOrRequest
+#include "SerDesInternals.hpp"   // SerPrimitive, TrivialArray, kSerMaxAlign
+#include "BaseCDRReader.hpp"     // BaseCDRReader
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// Deser* type descriptors — parallel to Ser* but carry write-side accessors.
+// ---------------------------------------------------------------------------
+
+struct DeserString
+{
+  void (*assign)(void * str, const char * src, size_t n);
+};
+
+struct DeserWString
+{
+  void (*assign)(void * str, const char16_t * src, size_t n);
+};
+
+struct DeserArray;
+struct DeserCSequence;
+struct DeserCppSequence;
+struct DeserCBoolVector;
+struct DeserCppBoolVector;
+struct DeserStruct;
+
+using DeserAnyType = std::variant<
+  SerPrimitive,    // reuse: cdr_size/cdr_align/native_size/needs_bswap/trivial_at_align
+  DeserString,
+  DeserWString,
+  DeserArray,
+  DeserCSequence,
+  DeserCppSequence,
+  DeserCBoolVector,
+  DeserCppBoolVector,
+  DeserStruct
+>;
+
+struct DeserMember
+{
+  const DeserAnyType * type;   // non-owning; points into DeserTypeStorage::nodes
+  bool is_key;
+  uint32_t native_offset;
+};
+
+struct DeserStruct
+{
+  bool has_keys;
+  size_t native_size = 0;
+  std::span<const DeserMember> members;
+  TrivialArray trivial_at_align = {};
+};
+
+// Flat arena owning all DeserAnyType nodes and DeserMember entries for an entire
+// message type tree.  Both vectors are pre-reserved so that pointers / spans
+// into them remain stable after construction.
+struct DeserTypeStorage
+{
+  std::vector<DeserAnyType> nodes;
+  std::vector<DeserMember> all_members;
+};
+
+struct DeserArray
+{
+  const DeserAnyType * element;  // non-owning
+  size_t count;
+  size_t native_elem_stride;
+  size_t fixed_cdr_stride = 0;
+  TrivialArray trivial_at_align = {};
+};
+
+// rosidl C sequence: { T* data; size_t size; size_t capacity }
+struct DeserCSequence
+{
+  const DeserAnyType * element;  // non-owning
+  size_t native_elem_stride;
+  size_t fixed_cdr_stride = 0;
+  TrivialArray trivial_at_align = {};
+  bool (* resize)(void * seq, size_t n);   // returns false on alloc failure
+  void * (* mut_contents)(void * seq);     // returns data pointer
+};
+
+// C++ std::vector<T> (T != bool): { T* begin; T* end; T* cap }
+struct DeserCppSequence
+{
+  const DeserAnyType * element;  // non-owning
+  size_t native_elem_stride;
+  size_t fixed_cdr_stride = 0;
+  TrivialArray trivial_at_align = {};
+  void (* resize)(void * seq, size_t n);   // calls resize_function (no return)
+  void * (* mut_contents)(void * seq);     // returns begin pointer
+};
+
+// rosidl C bool sequence: { bool* data; size_t size; size_t capacity }
+struct DeserCBoolVector
+{
+  bool (* resize)(void * seq, size_t n);   // rosidl resize_function; returns false on failure
+  void (* assign_byte)(void * seq, size_t idx, uint8_t val);  // writes data[idx]
+};
+
+// C++ std::vector<bool>: bit-packed; use introspection callbacks
+struct DeserCppBoolVector
+{
+  void (* resize)(void * seq, size_t n);   // rosidl resize_function (no return)
+  void (* assign_fn)(void * seq, size_t idx, const void * val);  // rosidl assign_function
+};
+
+// Build a DeserStruct from a MessageMembersVariant.
+std::pair<DeserStruct, DeserTypeStorage> make_deser_struct(MessageMembersVariant members);
+
+// ---------------------------------------------------------------------------
+// CDRDeserializer — implements BaseCDRReader using the Deser* type system.
+// ---------------------------------------------------------------------------
+class CDRDeserializer final : public BaseCDRReader
+{
+public:
+  explicit CDRDeserializer(MessageMembersVariant members, SampleOrRequest variant);
+
+  void deserialize(
+    void * dst, const void * cdr, size_t cdrsize, SampleOrKey what) const override;
+
+  void extractkey(
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const override;
+
+  void extractkey_be(
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const override;
+
+  size_t print(
+    char * dst, size_t dstsize, const void * cdr, size_t cdrsize,
+    SampleOrKey what) const override;
+
+private:
+  void extractkey_impl(
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
+    SampleOrKey what, bool output_be) const;
+
+  DeserTypeStorage m_storage;
+  DeserStruct m_root;
+  SampleOrRequest m_variant;
+};
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // DESER_TYPE_SUPPORT_HPP_

--- a/rmw_cyclonedds_cpp/src/SerDesInternals.hpp
+++ b/rmw_cyclonedds_cpp/src/SerDesInternals.hpp
@@ -1,0 +1,173 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef SER_DES_INTERNALS_HPP_
+#define SER_DES_INTERNALS_HPP_
+
+// Private implementation utilities shared between SerTypeSupport.cpp and
+// DeserTypeSupport.cpp. Not part of the public API.
+
+#include <array>
+#include <bit>
+#include <cstdint>
+#include <cstring>
+
+#include "SizeTypeSupport.hpp"  // for ROSIDL_TypeKind
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// Trivial-at-align helpers (shared by Ser* and Deser* type descriptors)
+// ---------------------------------------------------------------------------
+
+static constexpr size_t kSerMaxAlign = 8;
+using TrivialArray = std::array<bool, kSerMaxAlign>;
+
+struct SerPrimitive
+{
+  uint8_t cdr_size;    // bytes in CDR (1/2/4/8)
+  uint8_t cdr_align;   // CDR alignment (same as cdr_size for XCDR1 primitives)
+  uint8_t native_size; // sizeof() on this host (may differ from cdr_size, e.g. bool)
+  bool needs_bswap;    // true if byte-swap is required (BE host or native != CDR width)
+  TrivialArray trivial_at_align = {};
+  // trivial_at_align[a] = (a % cdr_align == 0) && !needs_bswap
+};
+
+static constexpr bool host_needs_bswap()
+{
+  return std::endian::native != std::endian::little;
+}
+
+// ---------------------------------------------------------------------------
+// Byte-swap helpers
+// ---------------------------------------------------------------------------
+
+template<size_t N>
+static void bswap_n(void * dst, const void * src);
+
+template<>
+inline void bswap_n<1>(void * dst, const void * src)
+{
+  std::memcpy(dst, src, 1);
+}
+template<>
+inline void bswap_n<2>(void * dst, const void * src)
+{
+  uint16_t v; std::memcpy(&v, src, 2);
+  v = static_cast<uint16_t>((v >> 8) | (v << 8));
+  std::memcpy(dst, &v, 2);
+}
+template<>
+inline void bswap_n<4>(void * dst, const void * src)
+{
+  uint32_t v; std::memcpy(&v, src, 4);
+  v = (v >> 24) | ((v & 0x00ff0000u) >> 8) | ((v & 0x0000ff00u) << 8) | (v << 24);
+  std::memcpy(dst, &v, 4);
+}
+template<>
+inline void bswap_n<8>(void * dst, const void * src)
+{
+  uint64_t v; std::memcpy(&v, src, 8);
+  v = (v >> 56) |
+    ((v & 0x00ff000000000000ull) >> 40) |
+    ((v & 0x0000ff0000000000ull) >> 24) |
+    ((v & 0x000000ff00000000ull) >> 8) |
+    ((v & 0x00000000ff000000ull) << 8) |
+    ((v & 0x0000000000ff0000ull) << 24) |
+    ((v & 0x000000000000ff00ull) << 40) |
+    (v << 56);
+  std::memcpy(dst, &v, 8);
+}
+
+// ---------------------------------------------------------------------------
+// Primitive kind → sizes
+// ---------------------------------------------------------------------------
+
+static inline uint8_t native_size_of_kind(ROSIDL_TypeKind kind)
+{
+  switch (kind) {
+    case ROSIDL_TypeKind::FLOAT:    return sizeof(float);
+    case ROSIDL_TypeKind::DOUBLE:   return sizeof(double);
+    case ROSIDL_TypeKind::CHAR:     return sizeof(char);
+    case ROSIDL_TypeKind::WCHAR:    return sizeof(char16_t);
+    case ROSIDL_TypeKind::BOOLEAN:  return sizeof(bool);
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:     return 1;
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:    return 2;
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:    return 4;
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:    return 8;
+    default:                        return 0;
+  }
+}
+
+static inline uint8_t cdr_size_of_kind(ROSIDL_TypeKind kind)
+{
+  switch (kind) {
+    case ROSIDL_TypeKind::FLOAT:    return 4;
+    case ROSIDL_TypeKind::DOUBLE:   return 8;
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:    return 2;
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:     return 1;
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:    return 2;
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:    return 4;
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:    return 8;
+    default:                        return 0;
+  }
+}
+
+// Native stride for a C primitive element in a fixed array.
+static inline size_t c_elem_native_stride(ROSIDL_TypeKind kind)
+{
+  return native_size_of_kind(kind);
+}
+
+static inline bool prim_trivial(uint8_t cdr_align, bool needs_bswap, size_t align_offset)
+{
+  if (needs_bswap) { return false; }
+  return (align_offset % cdr_align) == 0;
+}
+
+static inline TrivialArray make_prim_trivial_array(uint8_t cdr_align, bool needs_bswap)
+{
+  TrivialArray arr{};
+  for (size_t a = 0; a < kSerMaxAlign; ++a) {
+    arr[a] = prim_trivial(cdr_align, needs_bswap, a);
+  }
+  return arr;
+}
+
+static inline SerPrimitive make_ser_primitive(ROSIDL_TypeKind kind)
+{
+  uint8_t cdr_size = cdr_size_of_kind(kind);
+  uint8_t nat_size = native_size_of_kind(kind);
+  bool needs_bswap = host_needs_bswap() || (nat_size != cdr_size);
+  return SerPrimitive{
+    cdr_size, cdr_size,
+    nat_size, needs_bswap,
+    make_prim_trivial_array(cdr_size, needs_bswap)
+  };
+}
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // SER_DES_INTERNALS_HPP_

--- a/rmw_cyclonedds_cpp/src/SerTypeSupport.cpp
+++ b/rmw_cyclonedds_cpp/src/SerTypeSupport.cpp
@@ -512,11 +512,13 @@ struct SerializeCursor
 };
 
 // Write one primitive value, handling bswap and native_size != cdr_size.
+// Bswap is a compile-time constant: true on BE hosts or when native != cdr size.
+template<bool Bswap>
 static void ser_write_primitive(
   SerializeCursor & c, const void * src, const SerPrimitive & p)
 {
   c.align(p.cdr_align);
-  if (!p.needs_bswap) {
+  if constexpr (!Bswap) {
     c.put_bytes(src, p.cdr_size);
   } else {
     // Advance to make room, then bswap into the just-written slot.
@@ -536,23 +538,28 @@ static void ser_write_primitive(
 }
 
 // Forward declarations
+template<bool Bswap>
 static void ser_write(SerializeCursor & c, const void * data,
   const SerAnyType & t, SampleOrKey what);
+template<bool Bswap>
 static void ser_write_struct(SerializeCursor & c, const void * data,
   const SerStruct & s, SampleOrKey what);
+template<bool Bswap>
 static void ser_write_many(SerializeCursor & c, const void * base,
   size_t native_stride, size_t count, const SerAnyType & elem, SampleOrKey what);
 
+template<bool Bswap>
 static void ser_write_many(
   SerializeCursor & c, const void * base,
   size_t native_stride, size_t count, const SerAnyType & elem, SampleOrKey what)
 {
   for (size_t i = 0; i < count; ++i) {
     const void * p = static_cast<const char *>(base) + i * native_stride;
-    ser_write(c, p, elem, what);
+    ser_write<Bswap>(c, p, elem, what);
   }
 }
 
+template<bool Bswap>
 static void ser_write(
   SerializeCursor & c, const void * data,
   const SerAnyType & t, SampleOrKey what)
@@ -562,7 +569,7 @@ static void ser_write(
       using T = std::decay_t<decltype(v)>;
 
       if constexpr (std::is_same_v<T, SerPrimitive>) {
-        ser_write_primitive(c, data, v);
+        ser_write_primitive<Bswap>(c, data, v);
 
       } else if constexpr (std::is_same_v<T, SerString>) {
         const char * str_data = v.get_data(data);
@@ -580,7 +587,7 @@ static void ser_write(
         uint32_t byte_len = static_cast<uint32_t>(str_size * 2);
         c.align(4);
         c.put_bytes(&byte_len, 4);
-        if (!host_needs_bswap()) {
+        if constexpr (!Bswap) {
           c.put_bytes(str_data, byte_len);
         } else {
           for (size_t i = 0; i < str_size; ++i) {
@@ -614,11 +621,8 @@ static void ser_write(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           // Bulk memcpy: all elements trivially serialized from this alignment
           c.put_bytes(data, v.count * v.native_elem_stride);
-        } else if (v.fixed_cdr_stride > 0) {
-          // Fixed CDR size but not trivial (e.g. BE host): per-element with bswap
-          ser_write_many(c, data, v.native_elem_stride, v.count, *v.element, what);
         } else {
-          ser_write_many(c, data, v.native_elem_stride, v.count, *v.element, what);
+          ser_write_many<Bswap>(c, data, v.native_elem_stride, v.count, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, SerCSequence>) {
@@ -634,7 +638,7 @@ static void ser_write(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           c.put_bytes(seq->ptr, seq->size * v.native_elem_stride);
         } else {
-          ser_write_many(c, seq->ptr, v.native_elem_stride, seq->size, *v.element, what);
+          ser_write_many<Bswap>(c, seq->ptr, v.native_elem_stride, seq->size, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, SerCppSequence>) {
@@ -651,15 +655,16 @@ static void ser_write(
         if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
           c.put_bytes(vec->begin, count * v.native_elem_stride);
         } else {
-          ser_write_many(c, vec->begin, v.native_elem_stride, count, *v.element, what);
+          ser_write_many<Bswap>(c, vec->begin, v.native_elem_stride, count, *v.element, what);
         }
 
       } else if constexpr (std::is_same_v<T, SerStruct>) {
-        ser_write_struct(c, data, v, what);
+        ser_write_struct<Bswap>(c, data, v, what);
       }
     }, t);
 }
 
+template<bool Bswap>
 static void ser_write_struct(
   SerializeCursor & c, const void * data,
   const SerStruct & s, SampleOrKey what)
@@ -672,7 +677,7 @@ static void ser_write_struct(
   for (const auto & member : s.members) {
     if (all_fields || member.is_key) {
       const void * field = static_cast<const char *>(data) + member.native_offset;
-      ser_write(c, field, *member.type, what);
+      ser_write<Bswap>(c, field, *member.type, what);
     }
   }
 }
@@ -706,7 +711,7 @@ void CDRSerializer::serialize(void * dest, const void * data, SampleOrKey what) 
 
   if (what == SampleOrKey::Sample && m_variant == SampleOrRequest::Request) {
     auto * req = static_cast<const cdds_request_wrapper_t *>(data);
-    if (!host_needs_bswap()) {
+    if constexpr (!host_needs_bswap()) {
       c.put_bytes(&req->header.guid, sizeof(req->header.guid));
       c.put_bytes(&req->header.seq,  sizeof(req->header.seq));
     } else {
@@ -717,7 +722,7 @@ void CDRSerializer::serialize(void * dest, const void * data, SampleOrKey what) 
   }
 
   if (what == SampleOrKey::Sample || m_root.has_keys) {
-    ser_write_struct(c, data, m_root, what);
+    ser_write_struct<host_needs_bswap()>(c, data, m_root, what);
   }
   c.rebase(-4);
 }

--- a/rmw_cyclonedds_cpp/src/SerTypeSupport.cpp
+++ b/rmw_cyclonedds_cpp/src/SerTypeSupport.cpp
@@ -1,0 +1,750 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SerTypeSupport.hpp"
+#include "SerDesInternals.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "rosidl_runtime_c/string_functions.h"
+#include "rosidl_runtime_c/u16string_functions.h"
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// String accessors for C and C++ string types
+// ---------------------------------------------------------------------------
+
+static const char * c_string_data(const void * s)
+{
+  return static_cast<const rosidl_runtime_c__String *>(s)->data;
+}
+static size_t c_string_size(const void * s)
+{
+  return static_cast<const rosidl_runtime_c__String *>(s)->size;
+}
+static const char16_t * c_wstring_data(const void * s)
+{
+  return reinterpret_cast<const char16_t *>(
+    static_cast<const rosidl_runtime_c__U16String *>(s)->data);
+}
+static size_t c_wstring_size(const void * s)
+{
+  return static_cast<const rosidl_runtime_c__U16String *>(s)->size;
+}
+static const char * cpp_string_data(const void * s)
+{
+  return static_cast<const std::string *>(s)->data();
+}
+static size_t cpp_string_size(const void * s)
+{
+  return static_cast<const std::string *>(s)->size();
+}
+static const char16_t * cpp_wstring_data(const void * s)
+{
+  return static_cast<const std::u16string *>(s)->data();
+}
+static size_t cpp_wstring_size(const void * s)
+{
+  return static_cast<const std::u16string *>(s)->size();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+template<typename T>
+static const SerAnyType * alloc_ser(SerTypeStorage & store, T value)
+{
+  assert(store.nodes.size() < store.nodes.capacity());
+  store.nodes.emplace_back(std::move(value));
+  return &store.nodes.back();
+}
+
+// Forward declarations
+static SerStruct make_ser_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  SerTypeStorage & store);
+static SerStruct make_ser_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  SerTypeStorage & store);
+static void ser_stamp_trivial_struct(SerStruct & s);
+
+// ---------------------------------------------------------------------------
+// Element builders — C
+// ---------------------------------------------------------------------------
+
+static const SerAnyType * make_ser_element_c(
+  const rosidl_typesupport_introspection_c__MessageMember & m,
+  SerTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+    case ROSIDL_TypeKind::DOUBLE:
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_ser(store, make_ser_primitive(ROSIDL_TypeKind(m.type_id_)));
+    case ROSIDL_TypeKind::STRING:
+      return alloc_ser(store, SerString{c_string_data, c_string_size});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_ser(store, SerWString{c_wstring_data, c_wstring_size});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_ser_struct_c(
+        static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
+          m.members_->data), store);
+      return alloc_ser(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_ser_element_c: unknown type kind");
+  }
+}
+
+static SerStruct make_ser_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  SerTypeStorage & store)
+{
+  SerStruct st;
+  st.has_keys = false;
+  st.is_self_contained = true;
+  st.native_size = impl->size_of_;
+
+  struct LocalMember { const SerAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+    const ROSIDL_TypeKind kind = ROSIDL_TypeKind(m.type_id_);
+
+    const SerAnyType * elem = make_ser_element_c(m, store);
+
+    const SerAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      // Fixed array
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<SerStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(rosidl_runtime_c__String);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(rosidl_runtime_c__U16String);
+      } else {
+        nat_stride = c_elem_native_stride(kind);
+      }
+      member_type = alloc_ser(store, SerArray{elem, m.array_size_, nat_stride});
+    } else if (kind == ROSIDL_TypeKind::BOOLEAN) {
+      // C bool sequence: { bool* data; size_t size; size_t capacity }
+      member_type = alloc_ser(store, SerCBoolVector{});
+    } else {
+      // rosidl C dynamic sequence: { T* data; size_t size; size_t capacity }
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<SerStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(rosidl_runtime_c__String);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(rosidl_runtime_c__U16String);
+      } else {
+        nat_stride = c_elem_native_stride(kind);
+      }
+      member_type = alloc_ser(store, SerCSequence{elem, nat_stride});
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(SerMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const SerMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+// ---------------------------------------------------------------------------
+// Element builders — CPP
+// ---------------------------------------------------------------------------
+
+static const SerAnyType * make_ser_element_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMember & m,
+  SerTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+    case ROSIDL_TypeKind::DOUBLE:
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_ser(store, make_ser_primitive(ROSIDL_TypeKind(m.type_id_)));
+    case ROSIDL_TypeKind::STRING:
+      return alloc_ser(store, SerString{cpp_string_data, cpp_string_size});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_ser(store, SerWString{cpp_wstring_data, cpp_wstring_size});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_ser_struct_cpp(
+        static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+          m.members_->data), store);
+      return alloc_ser(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_ser_element_cpp: unknown type kind");
+  }
+}
+
+static SerStruct make_ser_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  SerTypeStorage & store)
+{
+  SerStruct st;
+  st.has_keys = false;
+  st.is_self_contained = true;
+  st.native_size = impl->size_of_;
+
+  struct LocalMember { const SerAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+    const ROSIDL_TypeKind kind = ROSIDL_TypeKind(m.type_id_);
+
+    const SerAnyType * elem = make_ser_element_cpp(m, store);
+
+    const SerAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      // Fixed-size array
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<SerStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(std::string);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(std::u16string);
+      } else {
+        nat_stride = native_size_of_kind(kind);
+      }
+      member_type = alloc_ser(store, SerArray{elem, m.array_size_, nat_stride});
+    } else if (kind == ROSIDL_TypeKind::BOOLEAN) {
+      // C++ std::vector<bool>: bit-packed storage
+      member_type = alloc_ser(store, SerCppBoolVector{m.size_function, m.fetch_function});
+    } else {
+      // C++ std::vector<T>: { T* begin; T* end; T* cap }
+      size_t nat_stride;
+      if (kind == ROSIDL_TypeKind::MESSAGE) {
+        nat_stride = std::get<SerStruct>(*elem).native_size;
+      } else if (kind == ROSIDL_TypeKind::STRING) {
+        nat_stride = sizeof(std::string);
+      } else if (kind == ROSIDL_TypeKind::WSTRING) {
+        nat_stride = sizeof(std::u16string);
+      } else {
+        nat_stride = native_size_of_kind(kind);
+      }
+      member_type = alloc_ser(store, SerCppSequence{elem, nat_stride});
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(SerMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const SerMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+// ---------------------------------------------------------------------------
+// Post-build stamp pass: fill trivial_at_align and fixed_cdr_stride
+// ---------------------------------------------------------------------------
+
+static TrivialArray ser_trivial_of(const SerAnyType & t);
+static void ser_stamp_trivial(SerAnyType & t);
+
+// Simulate walking a struct from entry offset `a` and check all members are trivial.
+// `a` is 0..7. Returns true if entire struct is a single memcpy from that alignment.
+static bool struct_trivial_at(const SerStruct & s, size_t a)
+{
+  if (host_needs_bswap()) {
+    return false;
+  }
+  size_t cursor = a;
+  for (const auto & member : s.members) {
+    const SerAnyType & t = *member.type;
+    // Check trivial_at_align for this member at current cursor alignment
+    const TrivialArray & ta = ser_trivial_of(t);
+    if (!ta[cursor % kSerMaxAlign]) {
+      return false;
+    }
+    // Advance cursor by CDR size of this member (only valid if fixed)
+    size_t member_cdr_size = std::visit(
+      [](const auto & v) -> size_t {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, SerPrimitive>) {
+          return v.cdr_size;
+        } else if constexpr (std::is_same_v<T, SerStruct>) {
+          // only reachable if v itself is trivial
+          return v.native_size;
+        } else if constexpr (std::is_same_v<T, SerArray>) {
+          return (v.fixed_cdr_stride > 0) ? v.count * v.fixed_cdr_stride : 0;
+        }
+        return 0;
+      }, t);
+    if (member_cdr_size == 0) {
+      return false;
+    }
+    cursor += member_cdr_size;
+  }
+  // Also verify CDR struct size == native struct size (no layout gaps)
+  return (cursor - a) == s.native_size;
+}
+
+// Retrieve trivial_at_align from any SerAnyType node (already stamped).
+static TrivialArray ser_trivial_of(const SerAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> TrivialArray {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (
+        std::is_same_v<T, SerPrimitive> ||
+        std::is_same_v<T, SerStruct> ||
+        std::is_same_v<T, SerArray> ||
+        std::is_same_v<T, SerCSequence> ||
+        std::is_same_v<T, SerCppSequence>)
+      {
+        return v.trivial_at_align;
+      }
+      return TrivialArray{};  // SerString/SerWString/SerCBoolVector/SerCppBoolVector: all false
+    }, t);
+}
+
+static size_t ser_fixed_cdr_stride(const SerAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SerPrimitive>) {
+        return v.cdr_size;
+      } else if constexpr (std::is_same_v<T, SerStruct>) {
+        // Fixed if trivial at alignment 0 (implies uniform CDR == native)
+        return v.trivial_at_align[0] ? v.native_size : 0;
+      } else if constexpr (std::is_same_v<T, SerArray>) {
+        return (v.fixed_cdr_stride > 0) ? v.count * v.fixed_cdr_stride : 0;
+      }
+      return 0;
+    }, t);
+}
+
+static void ser_stamp_trivial(SerAnyType & t)
+{
+  std::visit(
+    [](auto & v) {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SerStruct>) {
+        ser_stamp_trivial_struct(v);
+      } else if constexpr (std::is_same_v<T, SerArray>) {
+        // element already stamped (owned by same parent struct, processed first)
+        v.fixed_cdr_stride = ser_fixed_cdr_stride(*v.element);
+        // Array trivial at alignment a: element trivial at a AND at (a + stride) % 8
+        // (the "CLEVERNESS" condition from trivsercache: same alignment repeats)
+        for (size_t a = 0; a < kSerMaxAlign; ++a) {
+          if (v.fixed_cdr_stride == 0) {
+            v.trivial_at_align[a] = false;
+          } else {
+            const TrivialArray & et = ser_trivial_of(*v.element);
+            v.trivial_at_align[a] =
+              et[a % kSerMaxAlign] &&
+              et[(a + v.fixed_cdr_stride) % kSerMaxAlign];
+          }
+        }
+      } else if constexpr (
+        std::is_same_v<T, SerCSequence> ||
+        std::is_same_v<T, SerCppSequence>)
+      {
+        v.fixed_cdr_stride = ser_fixed_cdr_stride(*v.element);
+        // trivial_at_align[a]: element is trivially serializable when the cursor
+        // is at offset 'a' AFTER the 4-byte length prefix has been written.
+        for (size_t a = 0; a < kSerMaxAlign; ++a) {
+          if (v.fixed_cdr_stride == 0) {
+            v.trivial_at_align[a] = false;
+          } else {
+            const TrivialArray & et = ser_trivial_of(*v.element);
+            v.trivial_at_align[a] =
+              et[a] &&
+              et[(a + v.fixed_cdr_stride) % kSerMaxAlign];
+          }
+        }
+      }
+      // SerPrimitive trivial_at_align already set at construction time.
+      // SerString/SerWString/SerCBoolVector/SerCppBoolVector: all-false (default).
+    }, t);
+}
+
+static void ser_stamp_trivial_struct(SerStruct & s)
+{
+  // Now compute trivial_at_align for this struct.
+  for (size_t a = 0; a < kSerMaxAlign; ++a) {
+    s.trivial_at_align[a] = struct_trivial_at(s, a);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public builder
+// ---------------------------------------------------------------------------
+
+std::pair<SerStruct, SerTypeStorage> make_ser_struct(MessageMembersVariant members)
+{
+  SerTypeStorage store;
+  // Count pass: determine how many nodes and members we need, then reserve.
+  auto counts = std::visit(
+    [](const auto * m) { return count_type_tree(m); }, members);
+  store.nodes.reserve(counts.nodes);
+  store.all_members.reserve(counts.members);
+
+  auto root = std::visit(
+    [&store](const auto * m) -> SerStruct {
+      using T = std::decay_t<decltype(*m)>;
+      if constexpr (std::is_same_v<T, MetaMessage<TypeGenerator::ROSIDL_C>>) {
+        return make_ser_struct_c(m, store);
+      } else {
+        return make_ser_struct_cpp(m, store);
+      }
+    }, members);
+  // Stamp pass: iterate all nodes in allocation order (children before parents).
+  for (auto & node : store.nodes) {
+    ser_stamp_trivial(node);
+  }
+  ser_stamp_trivial_struct(root);
+  return {std::move(root), std::move(store)};
+}
+
+// ---------------------------------------------------------------------------
+// SerializeCursor — inline write cursor, no virtual dispatch
+// ---------------------------------------------------------------------------
+
+struct SerializeCursor
+{
+  char * pos;
+  const char * origin;
+
+  explicit SerializeCursor(void * dst)
+  : pos(static_cast<char *>(dst)), origin(static_cast<char *>(dst)) {}
+
+  size_t offset() const {return static_cast<size_t>(pos - origin);}
+
+  void align(size_t n)
+  {
+    size_t mask = n - 1;
+    size_t rem = offset() & mask;
+    if (rem) {
+      size_t pad = n - rem;
+      std::memset(pos, 0, pad);
+      pos += pad;
+    }
+  }
+
+  void put_bytes(const void * src, size_t n)
+  {
+    std::memcpy(pos, src, n);
+    pos += n;
+  }
+
+  void put_zeros(size_t n)
+  {
+    std::memset(pos, 0, n);
+    pos += n;
+  }
+
+  void rebase(ptrdiff_t delta) {origin += delta;}
+};
+
+// Write one primitive value, handling bswap and native_size != cdr_size.
+static void ser_write_primitive(
+  SerializeCursor & c, const void * src, const SerPrimitive & p)
+{
+  c.align(p.cdr_align);
+  if (!p.needs_bswap) {
+    c.put_bytes(src, p.cdr_size);
+  } else {
+    // Advance to make room, then bswap into the just-written slot.
+    char * dst_slot = c.pos;
+    c.put_zeros(p.cdr_size);
+    // Offset src by (native_size - cdr_size) on BE hosts (same as CDRWriter)
+    const void * src_adj = (p.native_size > p.cdr_size)
+      ? static_cast<const char *>(src) + (p.native_size - p.cdr_size) : src;
+    switch (p.cdr_size) {
+      case 1: bswap_n<1>(dst_slot, src_adj); break;
+      case 2: bswap_n<2>(dst_slot, src_adj); break;
+      case 4: bswap_n<4>(dst_slot, src_adj); break;
+      case 8: bswap_n<8>(dst_slot, src_adj); break;
+      default: break;
+    }
+  }
+}
+
+// Forward declarations
+static void ser_write(SerializeCursor & c, const void * data,
+  const SerAnyType & t, SampleOrKey what);
+static void ser_write_struct(SerializeCursor & c, const void * data,
+  const SerStruct & s, SampleOrKey what);
+static void ser_write_many(SerializeCursor & c, const void * base,
+  size_t native_stride, size_t count, const SerAnyType & elem, SampleOrKey what);
+
+static void ser_write_many(
+  SerializeCursor & c, const void * base,
+  size_t native_stride, size_t count, const SerAnyType & elem, SampleOrKey what)
+{
+  for (size_t i = 0; i < count; ++i) {
+    const void * p = static_cast<const char *>(base) + i * native_stride;
+    ser_write(c, p, elem, what);
+  }
+}
+
+static void ser_write(
+  SerializeCursor & c, const void * data,
+  const SerAnyType & t, SampleOrKey what)
+{
+  std::visit(
+    [&](const auto & v) {
+      using T = std::decay_t<decltype(v)>;
+
+      if constexpr (std::is_same_v<T, SerPrimitive>) {
+        ser_write_primitive(c, data, v);
+
+      } else if constexpr (std::is_same_v<T, SerString>) {
+        const char * str_data = v.get_data(data);
+        size_t str_size = v.get_size(data);
+        uint32_t len = static_cast<uint32_t>(str_size + 1);
+        c.align(4);
+        c.put_bytes(&len, 4);
+        c.put_bytes(str_data, str_size);
+        char nul = '\0';
+        c.put_bytes(&nul, 1);
+
+      } else if constexpr (std::is_same_v<T, SerWString>) {
+        const char16_t * str_data = v.get_data(data);
+        size_t str_size = v.get_size(data);
+        uint32_t byte_len = static_cast<uint32_t>(str_size * 2);
+        c.align(4);
+        c.put_bytes(&byte_len, 4);
+        if (!host_needs_bswap()) {
+          c.put_bytes(str_data, byte_len);
+        } else {
+          for (size_t i = 0; i < str_size; ++i) {
+            uint16_t ch = static_cast<uint16_t>(str_data[i]);
+            bswap_n<2>(c.pos, &ch);
+            c.pos += 2;
+          }
+        }
+
+      } else if constexpr (std::is_same_v<T, SerCBoolVector>) {
+        // C bool sequence: { bool* data; size_t size; size_t cap }
+        struct SeqLayout { const void * ptr; size_t size; size_t cap; };
+        auto * seq = static_cast<const SeqLayout *>(data);
+        uint32_t cnt = static_cast<uint32_t>(seq->size);
+        c.align(4);
+        c.put_bytes(&cnt, 4);
+        c.put_bytes(seq->ptr, seq->size);
+
+      } else if constexpr (std::is_same_v<T, SerCppBoolVector>) {
+        // C++ std::vector<bool>: use introspection callbacks
+        uint32_t cnt = static_cast<uint32_t>(v.size_function(data));
+        c.align(4);
+        c.put_bytes(&cnt, 4);
+        for (uint32_t bi = 0; bi < cnt; ++bi) {
+          uint8_t val = 0;
+          v.fetch_function(data, bi, &val);
+          c.put_bytes(&val, 1);
+        }
+
+      } else if constexpr (std::is_same_v<T, SerArray>) {
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          // Bulk memcpy: all elements trivially serialized from this alignment
+          c.put_bytes(data, v.count * v.native_elem_stride);
+        } else if (v.fixed_cdr_stride > 0) {
+          // Fixed CDR size but not trivial (e.g. BE host): per-element with bswap
+          ser_write_many(c, data, v.native_elem_stride, v.count, *v.element, what);
+        } else {
+          ser_write_many(c, data, v.native_elem_stride, v.count, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, SerCSequence>) {
+        // rosidl C sequence: { T* data; size_t size; size_t capacity }
+        struct SeqLayout { const void * ptr; size_t size; size_t cap; };
+        auto * seq = static_cast<const SeqLayout *>(data);
+        uint32_t cnt32 = static_cast<uint32_t>(seq->size);
+        c.align(4);
+        c.put_bytes(&cnt32, 4);
+        if (seq->size == 0) {
+          return;
+        }
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          c.put_bytes(seq->ptr, seq->size * v.native_elem_stride);
+        } else {
+          ser_write_many(c, seq->ptr, v.native_elem_stride, seq->size, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, SerCppSequence>) {
+        // C++ std::vector<T>: { T* begin; T* end; T* cap }
+        struct VecLayout { const char * begin; const char * end; const char * cap; };
+        auto * vec = static_cast<const VecLayout *>(data);
+        size_t count = static_cast<size_t>(vec->end - vec->begin) / v.native_elem_stride;
+        uint32_t cnt32 = static_cast<uint32_t>(count);
+        c.align(4);
+        c.put_bytes(&cnt32, 4);
+        if (count == 0) {
+          return;
+        }
+        if (v.trivial_at_align[c.offset() % kSerMaxAlign]) {
+          c.put_bytes(vec->begin, count * v.native_elem_stride);
+        } else {
+          ser_write_many(c, vec->begin, v.native_elem_stride, count, *v.element, what);
+        }
+
+      } else if constexpr (std::is_same_v<T, SerStruct>) {
+        ser_write_struct(c, data, v, what);
+      }
+    }, t);
+}
+
+static void ser_write_struct(
+  SerializeCursor & c, const void * data,
+  const SerStruct & s, SampleOrKey what)
+{
+  if (what == SampleOrKey::Sample && s.trivial_at_align[c.offset() % kSerMaxAlign]) {
+    c.put_bytes(data, s.native_size);
+    return;
+  }
+  bool all_fields = (what == SampleOrKey::Sample || !s.has_keys);
+  for (const auto & member : s.members) {
+    if (all_fields || member.is_key) {
+      const void * field = static_cast<const char *>(data) + member.native_offset;
+      ser_write(c, field, *member.type, what);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CDRSerializer implementation
+// ---------------------------------------------------------------------------
+
+CDRSerializer::CDRSerializer(MessageMembersVariant members, SampleOrRequest variant)
+: m_storage{},
+  m_root{},
+  m_sizer(members, variant),
+  m_variant(variant),
+  m_type_generator(
+    std::holds_alternative<const MetaMessage<TypeGenerator::ROSIDL_C> *>(members)
+    ? TypeGenerator::ROSIDL_C : TypeGenerator::ROSIDL_Cpp)
+{
+  auto [root, storage] = make_ser_struct(members);
+  m_storage = std::move(storage);
+  m_root = std::move(root);
+}
+
+void CDRSerializer::serialize(void * dest, const void * data, SampleOrKey what) const
+{
+  SerializeCursor c(dest);
+
+  // 4-byte RTPS encoding header: {0x00, 0x01 (LE) or 0x00 (BE), 0x00, 0x00}
+  const unsigned char header[4] = {0, static_cast<unsigned char>(host_needs_bswap() ? 0 : 1), 0, 0};
+  c.put_bytes(header, 4);
+  c.rebase(+4);
+
+  if (what == SampleOrKey::Sample && m_variant == SampleOrRequest::Request) {
+    auto * req = static_cast<const cdds_request_wrapper_t *>(data);
+    if (!host_needs_bswap()) {
+      c.put_bytes(&req->header.guid, sizeof(req->header.guid));
+      c.put_bytes(&req->header.seq,  sizeof(req->header.seq));
+    } else {
+      bswap_n<8>(c.pos, &req->header.guid); c.pos += 8;
+      bswap_n<8>(c.pos, &req->header.seq);  c.pos += 8;
+    }
+    data = req->data;
+  }
+
+  if (what == SampleOrKey::Sample || m_root.has_keys) {
+    ser_write_struct(c, data, m_root, what);
+  }
+  c.rebase(-4);
+}
+
+size_t CDRSerializer::get_serialized_size(const void * data, SampleOrKey what) const
+{
+  return m_sizer.get_serialized_size(data, what);
+}
+
+size_t CDRSerializer::get_serialized_size_estimate(const void * data, SampleOrKey what) const
+{
+  return m_sizer.get_serialized_size_estimate(data, what);
+}
+
+size_t CDRSerializer::get_min_serialized_size(SampleOrKey what) const
+{
+  return m_sizer.get_min_serialized_size(what);
+}
+
+size_t CDRSerializer::get_max_serialized_size(SampleOrKey what) const
+{
+  return m_sizer.get_max_serialized_size(what);
+}
+
+TypeGenerator CDRSerializer::type_generator() const
+{
+  return m_type_generator;
+}
+
+}  // namespace rmw_cyclonedds_cpp

--- a/rmw_cyclonedds_cpp/src/SerTypeSupport.hpp
+++ b/rmw_cyclonedds_cpp/src/SerTypeSupport.hpp
@@ -1,0 +1,166 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef SER_TYPE_SUPPORT_HPP_
+#define SER_TYPE_SUPPORT_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "SizeTypeSupport.hpp"   // for MessageMembersVariant, SampleOrKey, SampleOrRequest, CDRSizer
+#include "BaseCDRWriter.hpp"
+#include "SerDesInternals.hpp"   // kSerMaxAlign, TrivialArray, SerPrimitive
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// Lightweight type descriptors for CDR serialization.
+// kSerMaxAlign, TrivialArray, SerPrimitive are defined in SerDesInternals.hpp.
+// ---------------------------------------------------------------------------
+
+struct SerString
+{
+  const char * (*get_data)(const void * str);   // returns pointer to char data
+  size_t (*get_size)(const void * str);         // returns char count (excl. NUL)
+};
+
+struct SerWString
+{
+  const char16_t * (*get_data)(const void * str);
+  size_t (*get_size)(const void * str);
+};
+
+struct SerArray;
+struct SerCSequence;
+struct SerCppSequence;
+struct SerCBoolVector;
+struct SerCppBoolVector;
+struct SerStruct;
+
+using SerAnyType = std::variant<
+  SerPrimitive,
+  SerString,
+  SerWString,
+  SerArray,
+  SerCSequence,
+  SerCppSequence,
+  SerCBoolVector,
+  SerCppBoolVector,
+  SerStruct
+>;
+
+struct SerMember
+{
+  const SerAnyType * type;    // non-owning; points into SerTypeStorage::nodes
+  bool is_key;
+  uint32_t native_offset;     // byte offset in the native C/C++ struct
+};
+
+struct SerStruct
+{
+  bool has_keys;
+  bool is_self_contained;
+  size_t native_size = 0;
+  std::span<const SerMember> members;
+  TrivialArray trivial_at_align = {};
+  // trivial_at_align[a]: entire struct can be memcpy'd when cursor is at offset a
+};
+
+// Flat arena owning all SerAnyType nodes and SerMember entries for an entire
+// message type tree.  Both vectors are pre-reserved so that pointers / spans
+// into them remain stable after construction.
+struct SerTypeStorage
+{
+  std::vector<SerAnyType> nodes;
+  std::vector<SerMember> all_members;
+};
+
+struct SerArray
+{
+  const SerAnyType * element;    // non-owning
+  size_t count;
+  size_t native_elem_stride;     // sizeof() one element on this host
+  size_t fixed_cdr_stride = 0;   // CDR bytes per element (0 if variable-size)
+  TrivialArray trivial_at_align = {};
+  // trivial_at_align[a]: all count elements can be memcpy'd from alignment a
+};
+
+// rosidl C sequence: { T* data; size_t size; size_t capacity }
+struct SerCSequence
+{
+  const SerAnyType * element;    // non-owning
+  size_t native_elem_stride;     // sizeof() one element on this host
+  size_t fixed_cdr_stride = 0;   // CDR bytes per element (0 if variable-size)
+  TrivialArray trivial_at_align = {};
+};
+
+// C++ std::vector<T> (T != bool): { T* begin; T* end; T* cap }
+struct SerCppSequence
+{
+  const SerAnyType * element;    // non-owning
+  size_t native_elem_stride;     // sizeof(T) on this host
+  size_t fixed_cdr_stride = 0;   // CDR bytes per element (0 if variable-size)
+  TrivialArray trivial_at_align = {};
+};
+
+// rosidl C bool sequence: { bool* data; size_t size; size_t capacity }
+struct SerCBoolVector {};
+
+// C++ std::vector<bool>: bit-packed; use introspection callbacks (always non-null)
+struct SerCppBoolVector
+{
+  size_t (* size_function)(const void *);
+  void (* fetch_function)(const void *, size_t, void *);
+};
+
+// ---------------------------------------------------------------------------
+// Build a SerStruct from a MessageMembersVariant.
+// ---------------------------------------------------------------------------
+std::pair<SerStruct, SerTypeStorage> make_ser_struct(MessageMembersVariant members);
+
+// ---------------------------------------------------------------------------
+// CDRSerializer — implements BaseCDRWriter::serialize().
+// Size methods delegate to CDRSizer.
+// ---------------------------------------------------------------------------
+class CDRSerializer final : public BaseCDRWriter
+{
+public:
+  explicit CDRSerializer(MessageMembersVariant members, SampleOrRequest variant);
+
+  // Implements actual CDR serialization.
+  void serialize(void * dest, const void * data, SampleOrKey what) const override;
+
+  // Size methods delegated to CDRSizer.
+  size_t get_serialized_size(const void * data, SampleOrKey what) const override;
+  size_t get_serialized_size_estimate(const void * data, SampleOrKey what) const override;
+  size_t get_min_serialized_size(SampleOrKey what) const override;
+  size_t get_max_serialized_size(SampleOrKey what) const override;
+
+  TypeGenerator type_generator() const override;
+
+private:
+  SerTypeStorage m_storage;
+  SerStruct m_root;
+  CDRSizer m_sizer;
+  SampleOrRequest m_variant;
+  TypeGenerator m_type_generator;
+};
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // SER_TYPE_SUPPORT_HPP_

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -37,6 +37,10 @@
 
 #include "TypeSupport2.hpp"
 #include "trivsercache.hpp"
+#ifdef USE_NEW_CDR_IMPL
+#include "SerTypeSupport.hpp"
+#include "DeserTypeSupport.hpp"
+#endif
 #include "bytewise.hpp"
 
 namespace rmw_cyclonedds_cpp
@@ -1559,11 +1563,43 @@ std::unique_ptr<BaseCDRWriter> make_cdr_writer(
   MessageMembersVariant members,
   SampleOrRequest variant)
 {
+  [[maybe_unused]] static const bool once = [] {
+#ifdef USE_NEW_CDR_IMPL
+    std::cerr << "[rmw_cyclonedds] CDR impl: NEW (CDRSerializer/CDRDeserializer)\n";
+#else
+    std::cerr << "[rmw_cyclonedds] CDR impl: OLD (CDRWriter/CDRReader + trivsercache)\n";
+#endif
+    return true;
+  }();
+#ifdef USE_NEW_CDR_IMPL
+  return std::make_unique<CDRSerializer>(members, variant);
+#else
   return std::make_unique<CDRWriter>(make_struct_value_type(members), variant);
+#endif
 }
 
 __attribute__((visibility("default")))
 std::unique_ptr<BaseCDRReader> make_cdr_reader(
+  MessageMembersVariant members,
+  SampleOrRequest variant)
+{
+#ifdef USE_NEW_CDR_IMPL
+  return std::make_unique<CDRDeserializer>(members, variant);
+#else
+  return std::make_unique<CDRReader>(make_struct_value_type(members), variant);
+#endif
+}
+
+__attribute__((visibility("default")))
+std::unique_ptr<BaseCDRWriter> make_cdr_writer_old(
+  MessageMembersVariant members,
+  SampleOrRequest variant)
+{
+  return std::make_unique<CDRWriter>(make_struct_value_type(members), variant);
+}
+
+__attribute__((visibility("default")))
+std::unique_ptr<BaseCDRReader> make_cdr_reader_old(
   MessageMembersVariant members,
   SampleOrRequest variant)
 {

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -249,6 +249,7 @@ class CDRWriter final : public BaseCDRWriter
 {
 public:
   const EncodingVersion eversion;
+  std::unique_ptr<StructValueType> m_owned_value_type;
   const StructValueType * m_root_value_type;
   const TriviallySerializedCache tsc;
   const SampleOrRequest m_variant;
@@ -258,10 +259,11 @@ public:
   const size_t max_serialized_key_size;   // Includes 4 bytes encoding header; SIZE_MAX if unbounded
 
 public:
-  explicit CDRWriter(const StructValueType * root_value_type, SampleOrRequest variant)
+  explicit CDRWriter(std::unique_ptr<StructValueType> root_value_type, SampleOrRequest variant)
   : eversion{EncodingVersion::XCDR1},
-    m_root_value_type{root_value_type},
-    tsc{root_value_type},
+    m_owned_value_type{std::move(root_value_type)},
+    m_root_value_type{m_owned_value_type.get()},
+    tsc{m_root_value_type},
     m_variant{variant},
     min_serialized_data_size{compute_serialized_size_bound(SampleOrKey::Sample, MinOrMax::Min)},
     min_serialized_key_size{compute_serialized_size_bound(SampleOrKey::Key, MinOrMax::Min)},
@@ -312,6 +314,11 @@ public:
   {
     SerializeCursor cursor(dst);
     serialize_top_level(cursor, src, what);
+  }
+
+  TypeGenerator type_generator() const override
+  {
+    return m_root_value_type->type_generator();
   }
 
 protected:
@@ -686,10 +693,10 @@ protected:
 };
 
 std::unique_ptr<BaseCDRWriter> make_cdr_writer(
-  const StructValueType * value_type,
+  std::unique_ptr<StructValueType> value_type,
   SampleOrRequest variant)
 {
-  return std::make_unique<CDRWriter>(value_type, variant);
+  return std::make_unique<CDRWriter>(std::move(value_type), variant);
 }
 
 template<typename Derived>

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -198,9 +198,9 @@ struct SerializeCursor final : public WriteCursorBase<SerializeCursor>
 struct ByteVectorCursor final : public WriteCursorBase<ByteVectorCursor>
 {
   size_t pos_;
-  std::vector<byte> & data_;
+  std::vector<std::byte> & data_;
 
-  explicit ByteVectorCursor(std::vector<byte> & data)
+  explicit ByteVectorCursor(std::vector<std::byte> & data)
   : pos_{0}, data_{data}
   {
   }
@@ -208,8 +208,7 @@ struct ByteVectorCursor final : public WriteCursorBase<ByteVectorCursor>
   size_t offset() const {return pos_;}
   void advance(size_t n_bytes)
   {
-    byte zero = static_cast<byte>(0);
-    data_.insert(data_.end(), n_bytes, zero);
+    data_.insert(data_.end(), n_bytes, std::byte{0});
     pos_ += n_bytes;
   }
   void * put_bytes(const void * bytes, size_t n_bytes)
@@ -217,7 +216,7 @@ struct ByteVectorCursor final : public WriteCursorBase<ByteVectorCursor>
     if (n_bytes == 0) {
       return nullptr;
     } else {
-      auto ucbytes = static_cast<const byte *>(bytes);
+      auto ucbytes = static_cast<const std::byte *>(bytes);
       data_.insert(data_.end(), ucbytes, ucbytes + n_bytes);
       pos_ += n_bytes;
       return data_.data() + data_.size() - n_bytes;
@@ -765,7 +764,7 @@ public:
   }
 
   void extractkey(
-    std::vector<byte> & dst, const void * cdr, size_t cdrsize,
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
     SampleOrKey what) const override
   {
     DeserializeCursor rdcursor(cdr, cdrsize);
@@ -774,7 +773,7 @@ public:
   }
 
   void extractkey_be(
-    std::vector<byte> & dst, const void * cdr, size_t cdrsize,
+    std::vector<std::byte> & dst, const void * cdr, size_t cdrsize,
     SampleOrKey what) const override
   {
     DeserializeCursor rdcursor(cdr, cdrsize);
@@ -1555,6 +1554,7 @@ protected:
   }
 };
 
+__attribute__((visibility("default")))
 std::unique_ptr<BaseCDRWriter> make_cdr_writer(
   MessageMembersVariant members,
   SampleOrRequest variant)
@@ -1562,6 +1562,7 @@ std::unique_ptr<BaseCDRWriter> make_cdr_writer(
   return std::make_unique<CDRWriter>(make_struct_value_type(members), variant);
 }
 
+__attribute__((visibility("default")))
 std::unique_ptr<BaseCDRReader> make_cdr_reader(
   MessageMembersVariant members,
   SampleOrRequest variant)

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -692,13 +692,6 @@ protected:
   }
 };
 
-std::unique_ptr<BaseCDRWriter> make_cdr_writer(
-  std::unique_ptr<StructValueType> value_type,
-  SampleOrRequest variant)
-{
-  return std::make_unique<CDRWriter>(std::move(value_type), variant);
-}
-
 template<typename Derived>
 struct ReadCursorBase : public CursorBase<Derived>
 {
@@ -748,17 +741,19 @@ class CDRReader final : public BaseCDRReader
 {
 public:
   const EncodingVersion eversion;
-  const StructValueType * m_root_value_type;
+  std::unique_ptr<StructValueType> m_root_value_type;
   const TriviallySerializedCache tsc;
   const SampleOrRequest m_variant;
 
 public:
-  explicit CDRReader(const StructValueType * root_value_type, SampleOrRequest variant)
+
+  explicit CDRReader(std::unique_ptr<StructValueType> root_value_type, SampleOrRequest variant)
   : eversion{EncodingVersion::XCDR1},
-    m_root_value_type{root_value_type},
-    tsc{root_value_type},
+    m_root_value_type{std::move(root_value_type)},
+    tsc{m_root_value_type.get()},
     m_variant{variant}
   {
+    assert(m_root_value_type);
   }
 
   void deserialize(void * dst, const void * cdr, size_t cdrsize, SampleOrKey what) const override
@@ -836,7 +831,7 @@ protected:
     }
     if (what == SampleOrKey::Sample || m_root_value_type->has_keys()) {
       deserialize_maybe_bswap(
-        src, static_cast<unsigned char *>(dst), m_root_value_type, what,
+        src, static_cast<unsigned char *>(dst), m_root_value_type.get(), what,
         bswap_src);
     }
     src.rebase(-4);
@@ -880,7 +875,7 @@ protected:
     // the top-level type has keys and so "all_fields_are_key" will be false
     ExtractKeyMode kmode = (what ==
       SampleOrKey::Key) ? ExtractKeyMode::Key : ExtractKeyMode::Sample;
-    extractkey_maybe_bswap(src, dst, m_root_value_type, kmode, bswap_src, bswap_dst);
+    extractkey_maybe_bswap(src, dst, m_root_value_type.get(), kmode, bswap_src, bswap_dst);
     dst.rebase(-4);
     src.rebase(-4);
   }
@@ -901,7 +896,7 @@ protected:
       print_maybe_bswap(src, dst, &u64, what, limit, bswap_src);
     }
     if (what == SampleOrKey::Sample || m_root_value_type->has_keys()) {
-      print_maybe_bswap(src, dst, m_root_value_type, what, limit, bswap_src);
+      print_maybe_bswap(src, dst, m_root_value_type.get(), what, limit, bswap_src);
     }
     src.rebase(-4);
   }
@@ -1560,10 +1555,17 @@ protected:
   }
 };
 
-std::unique_ptr<BaseCDRReader> make_cdr_reader(
-  const StructValueType * value_type,
+std::unique_ptr<BaseCDRWriter> make_cdr_writer(
+  MessageMembersVariant members,
   SampleOrRequest variant)
 {
-  return std::make_unique<CDRReader>(value_type, variant);
+  return std::make_unique<CDRWriter>(make_struct_value_type(members), variant);
+}
+
+std::unique_ptr<BaseCDRReader> make_cdr_reader(
+  MessageMembersVariant members,
+  SampleOrRequest variant)
+{
+  return std::make_unique<CDRReader>(make_struct_value_type(members), variant);
 }
 }  // namespace rmw_cyclonedds_cpp

--- a/rmw_cyclonedds_cpp/src/Serialization.hpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.hpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <vector>
 
+#include "BaseCDRWriter.hpp"
+#include "BaseCDRReader.hpp"
 #include "serdata.hpp"
 
 namespace rmw_cyclonedds_cpp
@@ -25,60 +27,6 @@ namespace rmw_cyclonedds_cpp
 std::pair<MessageMembersVariant, MessageMembersVariant>
 make_request_response_value_types(const rosidl_service_type_support_t * svc);
 
-enum class SampleOrKey
-{
-  Sample,
-  Key
-};
-
-enum class SampleOrRequest
-{
-  Sample,
-  Request
-};
-
-class BaseCDRWriter
-{
-public:
-  virtual size_t get_serialized_size(const void * data, SampleOrKey what) const = 0;
-  virtual size_t get_serialized_size_estimate(const void * data, SampleOrKey what) const = 0;
-
-  // includes 4 bytes encoding header
-  virtual size_t get_min_serialized_size(SampleOrKey what) const = 0;
-  // includes 4 bytes encoding header, SIZE_MAX if unbounded
-  virtual size_t get_max_serialized_size(SampleOrKey what) const = 0;
-
-  virtual void serialize(void * dest, const void * data, SampleOrKey what) const = 0;
-  virtual TypeGenerator type_generator() const = 0;
-  virtual ~BaseCDRWriter() = default;
-};
-
-std::unique_ptr<BaseCDRWriter> make_cdr_writer(
-  MessageMembersVariant members,
-  SampleOrRequest variant);
-
-class BaseCDRReader
-{
-public:
-  virtual void deserialize(
-    void * dest, const void * cdr, size_t cdrsize,
-    SampleOrKey what) const = 0;
-  virtual void extractkey(
-    std::vector<byte> & dest, const void * cdr, size_t cdrsize,
-    SampleOrKey what) const = 0;
-  virtual void extractkey_be(
-    std::vector<byte> & dst, const void * cdr, size_t cdrsize,
-    SampleOrKey what) const = 0;
-  virtual size_t print(
-    char * dst, size_t dstsize, const void * cdr, size_t cdrsize,
-    SampleOrKey what) const =  0;
-
-  virtual ~BaseCDRReader() = default;
-};
-
-std::unique_ptr<BaseCDRReader> make_cdr_reader(
-  MessageMembersVariant members,
-  SampleOrRequest variant);
 }  // namespace rmw_cyclonedds_cpp
 
 #endif  // SERIALIZATION_HPP_

--- a/rmw_cyclonedds_cpp/src/Serialization.hpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.hpp
@@ -47,11 +47,12 @@ public:
   virtual size_t get_max_serialized_size(SampleOrKey what) const = 0;
 
   virtual void serialize(void * dest, const void * data, SampleOrKey what) const = 0;
+  virtual TypeGenerator type_generator() const = 0;
   virtual ~BaseCDRWriter() = default;
 };
 
 std::unique_ptr<BaseCDRWriter> make_cdr_writer(
-  const StructValueType * value_type,
+  std::unique_ptr<StructValueType> value_type,
   SampleOrRequest variant);
 
 class BaseCDRReader

--- a/rmw_cyclonedds_cpp/src/Serialization.hpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.hpp
@@ -17,12 +17,14 @@
 #include <memory>
 #include <vector>
 
-#include "TypeSupport2.hpp"
-#include "rosidl_runtime_c/service_type_support_struct.h"
 #include "serdata.hpp"
 
 namespace rmw_cyclonedds_cpp
 {
+
+std::pair<MessageMembersVariant, MessageMembersVariant>
+make_request_response_value_types(const rosidl_service_type_support_t * svc);
+
 enum class SampleOrKey
 {
   Sample,
@@ -52,7 +54,7 @@ public:
 };
 
 std::unique_ptr<BaseCDRWriter> make_cdr_writer(
-  std::unique_ptr<StructValueType> value_type,
+  MessageMembersVariant members,
   SampleOrRequest variant);
 
 class BaseCDRReader
@@ -75,7 +77,7 @@ public:
 };
 
 std::unique_ptr<BaseCDRReader> make_cdr_reader(
-  const StructValueType * value_type,
+  MessageMembersVariant members,
   SampleOrRequest variant);
 }  // namespace rmw_cyclonedds_cpp
 

--- a/rmw_cyclonedds_cpp/src/SizeTypeSupport.cpp
+++ b/rmw_cyclonedds_cpp/src/SizeTypeSupport.cpp
@@ -1,0 +1,1000 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "SizeTypeSupport.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <variant>
+#include <vector>
+
+
+#include "rosidl_typesupport_introspection_c/message_introspection.h"
+#include "rosidl_typesupport_introspection_cpp/message_introspection.hpp"
+#include <string>
+#include "rosidl_runtime_c/string.h"
+#include "rosidl_runtime_c/u16string.h"
+
+namespace rmw_cyclonedds_cpp
+{
+
+
+// ---------------------------------------------------------------------------
+// Helpers to query properties from SzAnyType
+// ---------------------------------------------------------------------------
+
+static bool sz_is_self_contained(const SzAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> bool {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        return true;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        return v.is_self_contained;
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        return sz_is_self_contained(*v.element);
+      } else {
+        return false;  // SzString, SzWString, SzCSequence, SzCppSequence, SzCBoolVector, SzCppBoolVector
+      }
+    }, t);
+}
+
+// ---------------------------------------------------------------------------
+// Native memory stride of a sequence element (for C-style seq traversal)
+// ---------------------------------------------------------------------------
+
+static size_t sz_native_elem_stride_c(const SzAnyType & elem)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) { return v.cdr_size; }
+      if constexpr (std::is_same_v<T, SzStruct>)    { return v.native_size; }
+      if constexpr (std::is_same_v<T, SzString>)    { return sizeof(rosidl_runtime_c__String); }
+      if constexpr (std::is_same_v<T, SzWString>)   { return sizeof(rosidl_runtime_c__U16String); }
+      return size_t{0};
+    }, elem);
+}
+
+static size_t sz_native_elem_stride_cpp(const SzAnyType & elem)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) { return v.cdr_size; }
+      if constexpr (std::is_same_v<T, SzStruct>)    { return v.native_size; }
+      if constexpr (std::is_same_v<T, SzString>)    { return sizeof(std::string); }
+      if constexpr (std::is_same_v<T, SzWString>)   { return sizeof(std::u16string); }
+      return size_t{0};
+    }, elem);
+}
+
+// ---------------------------------------------------------------------------
+// make_sz_struct — builds SzStruct from introspection metadata
+// ---------------------------------------------------------------------------
+
+static SzStruct make_sz_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  SzTypeStorage & store);
+static SzStruct make_sz_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  SzTypeStorage & store);
+static void sz_stamp_fixed_struct(SzStruct & s);
+static void sz_stamp_fixed(SzAnyType & t);
+static size_t sz_first_field_align(const SzAnyType & t);
+static size_t sz_max_field_align(const SzAnyType & t);
+
+
+std::pair<SzStruct, SzTypeStorage> make_sz_struct(MessageMembersVariant members)
+{
+  SzTypeStorage store;
+  // Count pass: determine how many nodes and members we need, then reserve.
+  auto counts = std::visit(
+    [](const auto * m) { return count_type_tree(m); }, members);
+  store.nodes.reserve(counts.nodes);
+  store.all_members.reserve(counts.members);
+
+  auto root = std::visit(
+    [&store](const auto * m) -> SzStruct {
+      using T = std::decay_t<decltype(*m)>;
+      if constexpr (std::is_same_v<T, MetaMessage<TypeGenerator::ROSIDL_C>>) {
+        return make_sz_struct_c(m, store);
+      } else {
+        return make_sz_struct_cpp(m, store);
+      }
+    }, members);
+  // Stamp pass: iterate all nodes in allocation order (children before parents).
+  for (auto & node : store.nodes) {
+    sz_stamp_fixed(node);
+  }
+  sz_stamp_fixed_struct(root);
+  // Stamp fast-path cache on every SzMember so that sz_exact_struct can
+  // handle most members via a switch without entering std::visit.
+  for (auto & m : store.all_members) {
+    std::visit(
+      [&m](const auto & v) {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, SzPrimitive>) {
+          m.cache = {SzMemberKind::Fixed, v.cdr_align, v.cdr_size, 0, nullptr, nullptr};
+        } else if constexpr (std::is_same_v<T, SzStruct>) {
+          if (v.is_fixed) {
+            m.cache = {SzMemberKind::Fixed,
+              static_cast<uint8_t>(v.first_field_align), v.fixed_cdr_size, 0, nullptr, nullptr};
+          } else {
+            m.cache = {SzMemberKind::Struct, 0, 0, 0, nullptr, &v};
+          }
+        } else if constexpr (std::is_same_v<T, SzArray>) {
+          if (v.fixed_stride > 0 && v.count > 0) {
+            m.cache = {SzMemberKind::Fixed,
+              static_cast<uint8_t>(sz_first_field_align(*v.element)),
+              v.count * v.fixed_stride, 0, nullptr, nullptr};
+          }
+        } else if constexpr (std::is_same_v<T, SzString>) {
+          m.cache = {SzMemberKind::String, 0, 0, 0, nullptr, nullptr};
+        } else if constexpr (std::is_same_v<T, SzWString>) {
+          m.cache = {SzMemberKind::WString, 0, 0, 0, nullptr, nullptr};
+        } else if constexpr (std::is_same_v<T, SzCSequence>) {
+          if (v.fixed_stride > 0) {
+            m.cache = {SzMemberKind::CSeqFixed,
+              static_cast<uint8_t>(sz_max_field_align(*v.element)),
+              v.fixed_stride, 0, nullptr, nullptr};
+          }
+        } else if constexpr (std::is_same_v<T, SzCppSequence>) {
+          if (v.fixed_stride > 0) {
+            m.cache = {SzMemberKind::CppVecFixed,
+              static_cast<uint8_t>(sz_max_field_align(*v.element)),
+              v.fixed_stride, v.native_elem_stride, nullptr, nullptr};
+          }
+        } else if constexpr (std::is_same_v<T, SzCBoolVector>) {
+          m.cache = {SzMemberKind::BoolVecC, 0, 0, 0, nullptr, nullptr};
+        } else if constexpr (std::is_same_v<T, SzCppBoolVector>) {
+          m.cache = {SzMemberKind::BoolVecCpp, 0, 0, 0, v.size_function, nullptr};
+        }
+      }, *m.type);
+  }
+  return {std::move(root), std::move(store)};
+}
+
+// Allocate an SzAnyType into the flat storage arena and return a raw pointer.
+// Precondition: store.nodes has been reserve()'d so emplace_back won't reallocate.
+template<typename T>
+static const SzAnyType * alloc_sz(SzTypeStorage & store, T value)
+{
+  assert(store.nodes.size() < store.nodes.capacity());
+  store.nodes.emplace_back(std::move(value));
+  return &store.nodes.back();
+}
+
+// Build the element descriptor for a single member (before array/sequence wrapping).
+// (Forward declaration of make_sz_element removed — it was unused.)
+static const SzAnyType * make_sz_element_c(
+  const rosidl_typesupport_introspection_c__MessageMember & m,
+  SzTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+      return alloc_sz(store, SzPrimitive{4, 4});
+    case ROSIDL_TypeKind::DOUBLE:
+      return alloc_sz(store, SzPrimitive{8, 8});
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+      return alloc_sz(store, SzPrimitive{1, 1});
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+      return alloc_sz(store, SzPrimitive{2, 2});
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+      return alloc_sz(store, SzPrimitive{4, 4});
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_sz(store, SzPrimitive{8, 8});
+    case ROSIDL_TypeKind::STRING:
+      return alloc_sz(store, SzString{UINT32_MAX - 1});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_sz(store, SzWString{UINT32_MAX / 2});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_sz_struct_c(
+        static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(
+          m.members_->data), store);
+      return alloc_sz(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_sz_element_c: unknown type kind");
+  }
+}
+
+static SzStruct make_sz_struct_c(
+  const rosidl_typesupport_introspection_c__MessageMembers * impl,
+  SzTypeStorage & store)
+{
+  SzStruct st;
+  st.has_keys = false;
+  st.is_self_contained = true;
+  st.native_size = impl->size_of_;
+
+  // Collect members locally first — recursive make_sz_element_c calls may
+  // push child-struct members into store.all_members, so we must not
+  // interleave this struct's members with theirs.
+  struct LocalMember { const SzAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+
+    const SzAnyType * elem = make_sz_element_c(m, store);
+
+    const SzAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      member_type = alloc_sz(store, SzArray{elem, m.array_size_, 0, sz_native_elem_stride_c(*elem)});
+    } else {
+      uint32_t bound = (m.array_size_ != 0 && m.is_upper_bound_) ?
+        static_cast<uint32_t>(m.array_size_) : UINT32_MAX;
+      member_type = alloc_sz(store, SzCSequence{elem, bound, 0, sz_native_elem_stride_c(*elem)});
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    if (!sz_is_self_contained(*member_type)) {
+      st.is_self_contained = false;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  // Batch-append this struct's members (after all children are done).
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(SzMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const SzMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+static const SzAnyType * make_sz_element_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMember & m,
+  SzTypeStorage & store)
+{
+  switch (ROSIDL_TypeKind(m.type_id_)) {
+    case ROSIDL_TypeKind::FLOAT:
+      return alloc_sz(store, SzPrimitive{4, 4});
+    case ROSIDL_TypeKind::DOUBLE:
+      return alloc_sz(store, SzPrimitive{8, 8});
+    case ROSIDL_TypeKind::CHAR:
+    case ROSIDL_TypeKind::WCHAR:
+    case ROSIDL_TypeKind::BOOLEAN:
+    case ROSIDL_TypeKind::OCTET:
+    case ROSIDL_TypeKind::UINT8:
+    case ROSIDL_TypeKind::INT8:
+      return alloc_sz(store, SzPrimitive{1, 1});
+    case ROSIDL_TypeKind::UINT16:
+    case ROSIDL_TypeKind::INT16:
+      return alloc_sz(store, SzPrimitive{2, 2});
+    case ROSIDL_TypeKind::UINT32:
+    case ROSIDL_TypeKind::INT32:
+      return alloc_sz(store, SzPrimitive{4, 4});
+    case ROSIDL_TypeKind::UINT64:
+    case ROSIDL_TypeKind::INT64:
+      return alloc_sz(store, SzPrimitive{8, 8});
+    case ROSIDL_TypeKind::STRING:
+      return alloc_sz(store, SzString{UINT32_MAX - 1});
+    case ROSIDL_TypeKind::WSTRING:
+      return alloc_sz(store, SzWString{UINT32_MAX / 2});
+    case ROSIDL_TypeKind::MESSAGE: {
+      auto sub = make_sz_struct_cpp(
+        static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(
+          m.members_->data), store);
+      return alloc_sz(store, std::move(sub));
+    }
+    default:
+      throw std::runtime_error("make_sz_element_cpp: unknown type kind");
+  }
+}
+
+static SzStruct make_sz_struct_cpp(
+  const rosidl_typesupport_introspection_cpp::MessageMembers * impl,
+  SzTypeStorage & store)
+{
+  SzStruct st;
+  st.has_keys = false;
+  st.is_self_contained = true;
+  st.native_size = impl->size_of_;
+
+  // Collect members locally first — recursive make_sz_element_cpp calls may
+  // push child-struct members into store.all_members, so we must not
+  // interleave this struct's members with theirs.
+  struct LocalMember { const SzAnyType * type; bool is_key; uint32_t offset; };
+  std::vector<LocalMember> local;
+  local.reserve(impl->member_count_);
+
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+
+    const SzAnyType * elem = make_sz_element_cpp(m, store);
+
+    const SzAnyType * member_type;
+    if (!m.is_array_) {
+      member_type = elem;
+    } else if (m.array_size_ != 0 && !m.is_upper_bound_) {
+      member_type = alloc_sz(
+        store, SzArray{elem, m.array_size_, 0, sz_native_elem_stride_cpp(*elem)});
+    } else {
+      uint32_t bound = (m.array_size_ != 0 && m.is_upper_bound_) ?
+        static_cast<uint32_t>(m.array_size_) : UINT32_MAX;
+      if (ROSIDL_TypeKind(m.type_id_) == ROSIDL_TypeKind::BOOLEAN) {
+        // std::vector<bool> has bit-packed storage; use introspection size_function.
+        member_type = alloc_sz(store, SzCppBoolVector{bound, m.size_function});
+      } else {
+        member_type = alloc_sz(store, SzCppSequence{elem, bound, 0, sz_native_elem_stride_cpp(*elem)});
+      }
+    }
+
+    if (m.is_key_) {
+      st.has_keys = true;
+    }
+    if (!sz_is_self_contained(*member_type)) {
+      st.is_self_contained = false;
+    }
+    local.push_back({member_type, m.is_key_, m.offset_});
+  }
+  // Batch-append this struct's members (after all children are done).
+  const size_t member_start = store.all_members.size();
+  for (auto & lm : local) {
+    assert(store.all_members.size() < store.all_members.capacity());
+    store.all_members.push_back(SzMember{lm.type, lm.is_key, lm.offset});
+  }
+  st.members = std::span<const SzMember>(
+    store.all_members.data() + member_start,
+    store.all_members.size() - member_start);
+  return st;
+}
+
+// ---------------------------------------------------------------------------
+// CDRSizer — size cursor arithmetic mirroring CDRWriter::serialize_size_bound
+// ---------------------------------------------------------------------------
+
+enum class MinOrMax { Min, Max };
+
+struct SzCursor
+{
+  size_t offset = 0;
+  bool overflowed = false;
+
+  void align(size_t n)
+  {
+    // n is always 1, 2, 4, or 8 — use bitmask, not division
+    size_t mask = n - 1;
+    size_t rem = offset & mask;
+    if (rem) {
+      advance(n - rem);
+    }
+  }
+
+  void advance(size_t n)
+  {
+    if (__builtin_expect(n > SIZE_MAX - offset, 0)) {
+      overflowed = true;
+      offset = SIZE_MAX;
+    } else {
+      offset += n;
+    }
+  }
+
+  void rebase(ptrdiff_t delta)
+  {
+    offset = static_cast<size_t>(static_cast<ptrdiff_t>(offset) - delta);
+  }
+};
+
+static void sz_put_u32(SzCursor & c)
+{
+  c.align(4);
+  c.advance(4);
+}
+
+// Forward declarations for mutual recursion.
+template<SampleOrKey What>
+static bool sz_bound(SzCursor & c, const SzAnyType & t, MinOrMax mm);
+template<SampleOrKey What>
+static bool sz_bound_struct(SzCursor & c, const SzStruct & s, MinOrMax mm);
+template<SampleOrKey What>
+static bool sz_bound_many(
+  SzCursor & c, size_t count, const SzAnyType & elem, MinOrMax mm);
+
+template<SampleOrKey What>
+static bool sz_bound(SzCursor & c, const SzAnyType & t, MinOrMax mm)
+{
+  return std::visit(
+    [&](const auto & v) -> bool {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        c.align(v.cdr_align);
+        c.advance(v.cdr_size);
+        return true;
+      } else if constexpr (std::is_same_v<T, SzString>) {
+        sz_put_u32(c);  // length prefix
+        size_t chars = (mm == MinOrMax::Min) ? 0 : (v.bound == UINT32_MAX - 1 ? UINT32_MAX - 1 :
+          static_cast<size_t>(v.bound));
+        if (mm == MinOrMax::Max && v.bound == UINT32_MAX - 1) {
+          c.overflowed = true;
+          c.offset = SIZE_MAX;
+          return false;
+        }
+        c.advance(chars + 1);  // chars + NUL
+        return mm == MinOrMax::Min;  // fixed only if we assume empty string
+      } else if constexpr (std::is_same_v<T, SzWString>) {
+        sz_put_u32(c);  // byte-length prefix
+        if (mm == MinOrMax::Max && v.bound == UINT32_MAX / 2) {
+          c.overflowed = true;
+          c.offset = SIZE_MAX;
+          return false;
+        }
+        size_t chars = (mm == MinOrMax::Min) ? 0 : static_cast<size_t>(v.bound);
+        c.advance(chars * 2);
+        return mm == MinOrMax::Min;
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        return sz_bound_many<What>(c, v.count, *v.element, mm);
+      } else if constexpr (
+        std::is_same_v<T, SzCSequence> ||
+        std::is_same_v<T, SzCppSequence>)
+      {
+        sz_put_u32(c);
+        if (mm == MinOrMax::Min) {
+          return true;  // min = empty sequence = just the 4-byte length prefix
+        }
+        if (v.bound == UINT32_MAX) {
+          c.overflowed = true;
+          c.offset = SIZE_MAX;
+          return false;  // truly unbounded sequence
+        }
+        return sz_bound_many<What>(c, v.bound, *v.element, mm);
+      } else if constexpr (
+        std::is_same_v<T, SzCBoolVector> ||
+        std::is_same_v<T, SzCppBoolVector>)
+      {
+        size_t count = (mm == MinOrMax::Min) ? 0 : v.bound;
+        sz_put_u32(c);
+        c.advance(count);
+        return mm == MinOrMax::Min;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        return sz_bound_struct<What>(c, v, mm);
+      }
+      return false;
+    }, t);
+}
+
+template<SampleOrKey What>
+static bool sz_bound_many(
+  SzCursor & c, size_t count, const SzAnyType & elem, MinOrMax mm)
+{
+  if (count == 0) {
+    return false;
+  }
+  if (!sz_bound<What>(c, elem, mm)) {
+    return false;
+  }
+  if (count > 1) {
+    size_t before = c.offset;
+    if (!sz_bound<What>(c, elem, mm)) {
+      return false;
+    }
+    size_t elt_size = c.offset - before;
+    c.advance(elt_size * (count - 2));
+  }
+  return true;
+}
+
+template<SampleOrKey What>
+static bool sz_bound_struct(SzCursor & c, const SzStruct & s, MinOrMax mm)
+{
+  constexpr bool is_sample = (What == SampleOrKey::Sample);
+  bool fixed = true;
+  for (const auto & member : s.members) {
+    if constexpr (is_sample) {
+      if (!sz_bound<What>(c, *member.type, mm)) {
+        fixed = false;
+      }
+    } else {
+      if (!s.has_keys || member.is_key) {
+        if (!sz_bound<What>(c, *member.type, mm)) {
+          fixed = false;
+        }
+      }
+    }
+  }
+  return fixed;
+}
+
+template<SampleOrKey What>
+static size_t compute_bound(
+  const SzStruct & root, SampleOrRequest variant, MinOrMax mm)
+{
+  SzCursor c;
+
+  // RTPS header (4 bytes encoding descriptor, no alignment)
+  c.advance(4);
+  c.rebase(+4);
+
+  // Request wrapper header: 8-byte GUID + 8-byte sequence number
+  if constexpr (What == SampleOrKey::Sample) {
+    if (variant == SampleOrRequest::Request) {
+      c.advance(8);
+      c.advance(8);
+    }
+  }
+
+  if constexpr (What == SampleOrKey::Sample) {
+    bool ok = true;
+    try {
+      ok = sz_bound_struct<What>(c, root, mm);
+    } catch (...) {
+      ok = false;
+    }
+    if (!ok || c.overflowed) {
+      return SIZE_MAX;
+    }
+  } else {
+    if (root.has_keys) {
+      bool ok = true;
+      try {
+        ok = sz_bound_struct<What>(c, root, mm);
+      } catch (...) {
+        ok = false;
+      }
+      if (!ok || c.overflowed) {
+        return SIZE_MAX;
+      }
+    }
+  }
+
+  c.rebase(-4);
+  return c.overflowed ? SIZE_MAX : c.offset;
+}
+
+CDRSizer::CDRSizer(MessageMembersVariant members, SampleOrRequest variant)
+: m_storage{},
+  m_root{},
+  m_variant{variant},
+  m_min_data_size{0},
+  m_min_key_size{0},
+  m_max_data_size{0},
+  m_max_key_size{0}
+{
+  auto [root, storage] = make_sz_struct(members);
+  m_storage = std::move(storage);
+  m_root = std::move(root);
+  m_min_data_size = compute_bound<SampleOrKey::Sample>(m_root, variant, MinOrMax::Min);
+  m_min_key_size = compute_bound<SampleOrKey::Key>(m_root, variant, MinOrMax::Min);
+  m_max_data_size = compute_bound<SampleOrKey::Sample>(m_root, variant, MinOrMax::Max);
+  m_max_key_size = compute_bound<SampleOrKey::Key>(m_root, variant, MinOrMax::Max);
+}
+
+// ---------------------------------------------------------------------------
+// Exact size from data — walk the live message, measure variable parts.
+// For fixed-size types (min==max) this is never called.
+// ---------------------------------------------------------------------------
+
+template<SampleOrKey What>
+static size_t sz_exact(SzCursor & c, const void * data, const SzAnyType & t);
+template<SampleOrKey What>
+static size_t sz_exact_struct(SzCursor & c, const void * data, const SzStruct & s);
+
+template<SampleOrKey What>
+static void sz_exact_many(
+  SzCursor & c, const void * base, size_t elem_stride,
+  size_t count, const SzAnyType & elem)
+{
+  for (size_t i = 0; i < count; ++i) {
+    const void * p = static_cast<const char *>(base) + i * elem_stride;
+    sz_exact<What>(c, p, elem);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Post-build pass: stamp fixed_stride / is_fixed / fixed_cdr_size into nodes.
+// ---------------------------------------------------------------------------
+
+// Returns the CDR stride of a fixed-size element (0 if variable).
+// For SzStruct, requires alignment_invariant so the stride is safe at any
+// starting offset (used for SzArray members and as element of arrays).
+static size_t sz_fixed_stride(const SzAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        return v.cdr_size;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        return (v.is_fixed && v.alignment_invariant) ? v.fixed_cdr_size : 0;
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        return (v.fixed_stride > 0) ? v.count * v.fixed_stride : 0;
+      }
+      return 0;
+    }, t);
+}
+
+// Returns the CDR stride suitable for bulk-advancing through a homogeneous
+// sequence whose first element has been aligned.  Unlike sz_fixed_stride, this
+// does not require alignment_invariant — it only requires that the per-element
+// CDR size is a multiple of the element's first-field alignment, so that every
+// subsequent element is naturally aligned after the previous one.
+static size_t sz_seq_elem_stride(const SzAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        return v.cdr_size;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        if (!v.is_fixed) { return 0; }
+        // After c.align(max_field_align), element i sits at
+        // base + i * fixed_cdr_size.  That offset is correctly aligned for
+        // ALL fields iff fixed_cdr_size % max_field_align == 0.
+        if (v.fixed_cdr_size == 0) { return 0; }
+        return (v.fixed_cdr_size % v.max_field_align == 0)
+          ? v.fixed_cdr_size : 0;
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        return (v.fixed_stride > 0) ? v.count * v.fixed_stride : 0;
+      }
+      return 0;
+    }, t);
+}
+
+static void sz_stamp_fixed(SzAnyType & t)
+{
+  std::visit(
+    [](auto & v) {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzStruct>) {
+        sz_stamp_fixed_struct(v);
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        v.fixed_stride = sz_fixed_stride(*v.element);
+      } else if constexpr (
+        std::is_same_v<T, SzCSequence> ||
+        std::is_same_v<T, SzCppSequence>)
+      {
+        v.fixed_stride = sz_seq_elem_stride(*v.element);
+      }
+    }, t);
+}
+
+static size_t sz_first_field_align(const SzAnyType & t);
+
+static size_t sz_first_field_align_struct(const SzStruct & s)
+{
+  for (const auto & member : s.members) {
+    return sz_first_field_align(*member.type);
+  }
+  return 1;
+}
+
+static size_t sz_first_field_align(const SzAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        return v.cdr_align;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        return sz_first_field_align_struct(v);
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        return sz_first_field_align(*v.element);
+      }
+      return 4;  // strings, sequences start with u32
+    }, t);
+}
+
+static size_t sz_max_field_align_struct(const SzStruct & s)
+{
+  size_t mx = 1;
+  for (const auto & m : s.members) {
+    mx = std::max(mx, sz_max_field_align(*m.type));
+  }
+  return mx;
+}
+
+static size_t sz_max_field_align(const SzAnyType & t)
+{
+  return std::visit(
+    [](const auto & v) -> size_t {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        return v.cdr_align;
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        return v.max_field_align;
+      } else if constexpr (
+        std::is_same_v<T, SzArray> ||
+        std::is_same_v<T, SzCSequence> ||
+        std::is_same_v<T, SzCppSequence>)
+      {
+        return sz_max_field_align(*v.element);
+      }
+      return 4;  // strings, sequences: u32 header
+    }, t);
+}
+
+static void sz_stamp_fixed_struct(SzStruct & s)
+{
+  // Compute first-field alignment for the fast path in sz_exact_struct.
+  s.first_field_align = sz_first_field_align_struct(s);
+  s.max_field_align = sz_max_field_align_struct(s);
+  SzCursor min_c, max_c;
+  bool fixed = sz_bound_struct<SampleOrKey::Sample>(min_c, s, MinOrMax::Min);
+  if (fixed) {
+    sz_bound_struct<SampleOrKey::Sample>(max_c, s, MinOrMax::Max);
+    if (!max_c.overflowed && min_c.offset == max_c.offset) {
+      s.is_fixed = true;
+      // fixed_cdr_size is the net bytes consumed FROM OFFSET 0.
+      // For the fast path we need to know bytes after aligning: store as-is,
+      // sz_exact_struct will align first then advance by (min_c.offset - padding).
+      s.fixed_cdr_size = min_c.offset;
+
+      // Check whether the struct's CDR size is the same regardless of starting
+      // alignment.  When used as element stride inside arrays/sequences, the
+      // fast path can only bulk-advance if the size is alignment-invariant.
+      s.alignment_invariant = true;
+      for (size_t start = 1; start < 8; ++start) {
+        SzCursor probe;
+        probe.offset = start;
+        sz_bound_struct<SampleOrKey::Sample>(probe, s, MinOrMax::Min);
+        if (probe.offset - start != s.fixed_cdr_size) {
+          s.alignment_invariant = false;
+          break;
+        }
+      }
+    }
+  }
+}
+
+template<SampleOrKey What>
+static size_t sz_exact(SzCursor & c, const void * data, const SzAnyType & t)
+{
+  std::visit(
+    [&](const auto & v) {
+      using T = std::decay_t<decltype(v)>;
+      if constexpr (std::is_same_v<T, SzPrimitive>) {
+        c.align(v.cdr_align);
+        c.advance(v.cdr_size);
+      } else if constexpr (std::is_same_v<T, SzString>) {
+        struct CStrLayout { const char * data; size_t size; size_t capacity; };
+        auto * s = static_cast<const CStrLayout *>(data);
+        sz_put_u32(c);
+        c.advance(s->size + 1);
+      } else if constexpr (std::is_same_v<T, SzWString>) {
+        struct WStrLayout { const char16_t * data; size_t size; size_t capacity; };
+        auto * s = static_cast<const WStrLayout *>(data);
+        sz_put_u32(c);
+        c.advance(s->size * 2);
+      } else if constexpr (std::is_same_v<T, SzArray>) {
+        if (v.fixed_stride > 0 && v.count > 0) {
+          // Align to first element, then bulk advance; stride already includes
+          // inter-element padding for identical alignment.
+          size_t elem_align = sz_first_field_align(*v.element);
+          c.align(elem_align);
+          c.advance(v.count * v.fixed_stride);
+        } else {
+          sz_exact_many<What>(c, data, v.native_elem_stride, v.count, *v.element);
+        }
+      } else if constexpr (std::is_same_v<T, SzCSequence>) {
+        sz_put_u32(c);
+        struct SeqLayout { const void * data; size_t size; size_t capacity; };
+        auto * seq = static_cast<const SeqLayout *>(data);
+        size_t count = seq->size;
+        if (v.fixed_stride > 0) {
+          if (count > 0) {
+            c.align(sz_first_field_align(*v.element));
+          }
+          c.advance(count * v.fixed_stride);
+        } else {
+          sz_exact_many<What>(c, seq->data, v.native_elem_stride, count, *v.element);
+        }
+      } else if constexpr (std::is_same_v<T, SzCppSequence>) {
+        sz_put_u32(c);
+        struct VecLayout { const char * begin; const char * end; const char * cap; };
+        auto * vec = static_cast<const VecLayout *>(data);
+        size_t count = v.fixed_stride > 0
+          ? static_cast<size_t>(vec->end - vec->begin) / v.fixed_stride
+          : (v.native_elem_stride > 0
+            ? static_cast<size_t>(vec->end - vec->begin) / v.native_elem_stride
+            : 0);
+        if (v.fixed_stride > 0) {
+          if (count > 0) {
+            c.align(sz_first_field_align(*v.element));
+          }
+          c.advance(count * v.fixed_stride);
+        } else {
+          sz_exact_many<What>(c, vec->begin, v.native_elem_stride, count, *v.element);
+        }
+      } else if constexpr (std::is_same_v<T, SzCBoolVector>) {
+        sz_put_u32(c);
+        struct SeqLayout { const void * data; size_t size; size_t capacity; };
+        size_t count = static_cast<const SeqLayout *>(data)->size;
+        c.advance(count);
+      } else if constexpr (std::is_same_v<T, SzCppBoolVector>) {
+        sz_put_u32(c);
+        c.advance(v.size_function(data));
+      } else if constexpr (std::is_same_v<T, SzStruct>) {
+        sz_exact_struct<What>(c, data, v);
+      }
+    }, t);
+  return c.offset;
+}
+
+template<SampleOrKey What>
+static size_t sz_exact_struct(SzCursor & c, const void * data, const SzStruct & s)
+{
+  constexpr bool is_sample = (What == SampleOrKey::Sample);
+
+  // Fast path — fixed-size alignment-invariant struct, just advance.
+  if constexpr (is_sample) {
+    if (s.is_fixed && s.alignment_invariant) {
+      c.align(s.first_field_align);
+      c.advance(s.fixed_cdr_size);
+      return c.offset;
+    }
+  } else {
+    if (s.is_fixed && s.alignment_invariant && !s.has_keys) {
+      c.align(s.first_field_align);
+      c.advance(s.fixed_cdr_size);
+      return c.offset;
+    }
+  }
+
+  // Per-member sizing via precomputed SzMemberCache — avoids std::visit for
+  // all common types (primitives, fixed structs, strings, fixed-stride
+  // sequences).  Only the Slow fallback enters sz_exact / std::visit.
+  for (const auto & member : s.members) {
+    if constexpr (!is_sample) {
+      if (s.has_keys && !member.is_key) {
+        continue;
+      }
+    }
+    const void * field = static_cast<const char *>(data) + member.native_offset;
+    const auto & mc = member.cache;
+    switch (mc.kind) {
+      case SzMemberKind::Fixed:
+        c.align(mc.elem_align);
+        c.advance(mc.cdr_stride);
+        break;
+      case SzMemberKind::String: {
+        // Both rosidl_runtime_c__String and std::string have {ptr, size, ...}
+        size_t len = *reinterpret_cast<const size_t *>(
+          static_cast<const char *>(field) + sizeof(const char *));
+        sz_put_u32(c);
+        c.advance(len + 1);
+        break;
+      }
+      case SzMemberKind::WString: {
+        size_t len = *reinterpret_cast<const size_t *>(
+          static_cast<const char *>(field) + sizeof(const char16_t *));
+        sz_put_u32(c);
+        c.advance(len * 2);
+        break;
+      }
+      case SzMemberKind::CSeqFixed: {
+        // rosidl C sequence: { T* data; size_t size; size_t capacity; }
+        struct SeqLayout { const void * d; size_t sz; size_t cap; };
+        size_t n = static_cast<const SeqLayout *>(field)->sz;
+        sz_put_u32(c);
+        if (n > 0) { c.align(mc.elem_align); }
+        c.advance(n * mc.cdr_stride);
+        break;
+      }
+      case SzMemberKind::CppVecFixed: {
+        // C++ std::vector<T>: { T* begin; T* end; T* cap; }
+        struct VecLayout { const char * b; const char * e; const char * cap; };
+        auto * v = static_cast<const VecLayout *>(field);
+        size_t n = static_cast<size_t>(v->e - v->b) / mc.native_elem_stride;
+        sz_put_u32(c);
+        if (n > 0) { c.align(mc.elem_align); }
+        c.advance(n * mc.cdr_stride);
+        break;
+      }
+      case SzMemberKind::BoolVecC: {
+        struct SeqLayout { const void * d; size_t sz; size_t cap; };
+        size_t n = static_cast<const SeqLayout *>(field)->sz;
+        sz_put_u32(c);
+        c.advance(n);
+        break;
+      }
+      case SzMemberKind::BoolVecCpp: {
+        size_t n = mc.size_fn(field);
+        sz_put_u32(c);
+        c.advance(n);
+        break;
+      }
+      case SzMemberKind::Struct:
+        sz_exact_struct<What>(c, field, *mc.sub_struct);
+        break;
+      case SzMemberKind::Slow:
+        sz_exact<What>(c, field, *member.type);
+        break;
+    }
+  }
+  return c.offset;
+}
+
+// Internal helper: run the exact-size computation with a specific SampleOrKey
+// template argument.
+template<SampleOrKey What>
+static size_t sz_get_serialized_size_impl(
+  const SzStruct & root, SampleOrRequest variant, const void * data,
+  size_t mn, size_t mx)
+{
+  if (mn == mx) {
+    return mx;
+  }
+  SzCursor c;
+  c.advance(4);
+  c.rebase(+4);
+  if constexpr (What == SampleOrKey::Sample) {
+    if (variant == SampleOrRequest::Request) {
+      auto * req = static_cast<const cdds_request_wrapper_t *>(data);
+      c.advance(sizeof(req->header.guid));
+      c.advance(sizeof(req->header.seq));
+      data = req->data;
+    }
+    sz_exact_struct<What>(c, data, root);
+  } else {
+    if (root.has_keys) {
+      sz_exact_struct<What>(c, data, root);
+    }
+  }
+  c.rebase(-4);
+  return c.offset;
+}
+
+size_t CDRSizer::get_min_serialized_size(SampleOrKey what) const
+{
+  return (what == SampleOrKey::Sample) ? m_min_data_size : m_min_key_size;
+}
+
+size_t CDRSizer::get_max_serialized_size(SampleOrKey what) const
+{
+  return (what == SampleOrKey::Sample) ? m_max_data_size : m_max_key_size;
+}
+
+size_t CDRSizer::get_serialized_size(const void * data, SampleOrKey what) const
+{
+  if (what == SampleOrKey::Sample) {
+    return sz_get_serialized_size_impl<SampleOrKey::Sample>(
+      m_root, m_variant, data, m_min_data_size, m_max_data_size);
+  } else {
+    return sz_get_serialized_size_impl<SampleOrKey::Key>(
+      m_root, m_variant, data, m_min_key_size, m_max_key_size);
+  }
+}
+
+size_t CDRSizer::get_serialized_size_estimate(const void * data, SampleOrKey what) const
+{
+  const size_t mn = get_min_serialized_size(what);
+  const size_t mx = get_max_serialized_size(what);
+  if (mx <= 1024 || (mn > 0 && mx / mn == 1)) {
+    return mx;
+  }
+  return get_serialized_size(data, what);
+}
+
+}  // namespace rmw_cyclonedds_cpp

--- a/rmw_cyclonedds_cpp/src/SizeTypeSupport.hpp
+++ b/rmw_cyclonedds_cpp/src/SizeTypeSupport.hpp
@@ -1,0 +1,198 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef SIZE_TYPE_SUPPORT_HPP_
+#define SIZE_TYPE_SUPPORT_HPP_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "TypeSupport2.hpp"
+
+namespace rmw_cyclonedds_cpp
+{
+
+// ---------------------------------------------------------------------------
+// Lightweight value-type descriptors — only what CDR size computation needs.
+// These do NOT carry any data accessor callbacks; they are pure metadata.
+// ---------------------------------------------------------------------------
+
+struct SzPrimitive
+{
+  uint8_t cdr_size;   // bytes in CDR (1/2/4/8)
+  uint8_t cdr_align;  // alignment in CDR (same as cdr_size for all XCDR1 primitives)
+};
+
+struct SzString
+{
+  uint32_t bound;  // max char count excluding NUL; UINT32_MAX-1 means unbounded
+};
+
+struct SzWString
+{
+  uint32_t bound;  // max char16_t count; UINT32_MAX/2 means unbounded
+};
+
+struct SzArray;
+struct SzCSequence;
+struct SzCppSequence;
+struct SzCBoolVector;
+struct SzCppBoolVector;
+struct SzStruct;
+
+// Forward-declare the variant before the types that hold it.
+using SzAnyType = std::variant<
+  SzPrimitive,
+  SzString,
+  SzWString,
+  SzArray,
+  SzCSequence,
+  SzCppSequence,
+  SzCBoolVector,
+  SzCppBoolVector,
+  SzStruct
+>;
+
+// Precomputed fast-path tag for each member, set during the stamp pass.
+// Allows sz_exact_struct to size every common member type without std::visit.
+enum class SzMemberKind : uint8_t
+{
+  Fixed,          // align + advance (primitives, fixed structs, fixed arrays)
+  String,         // u32 + read native size + 1
+  WString,        // u32 + read native size * 2
+  CSeqFixed,      // u32 + read count from {ptr,size,cap} + align + count*stride
+  CppVecFixed,    // u32 + compute count from {begin,end,cap}/stride + align + count*stride
+  BoolVecC,       // u32 + read count from {ptr,size,cap}
+  BoolVecCpp,     // u32 + size_function(data)
+  Struct,         // recurse into sz_exact_struct directly (non-fixed nested struct)
+  Slow,           // fallback: call sz_exact (variable-stride arrays/sequences)
+};
+
+struct SzStruct;  // forward-declare for pointer in SzMemberCache
+
+struct SzMemberCache
+{
+  SzMemberKind kind = SzMemberKind::Slow;
+  uint8_t elem_align = 0;                    // CDR alignment (Fixed/seq fast paths)
+  size_t  cdr_stride = 0;                    // CDR bytes (Fixed) or CDR stride per element (seq)
+  size_t  native_elem_stride = 0;            // native bytes per element (CppVecFixed: divisor)
+  size_t (* size_fn)(const void *) = nullptr; // BoolVecCpp only
+  const SzStruct * sub_struct = nullptr;     // Struct kind: direct pointer, avoids std::visit
+};
+
+struct SzMember
+{
+  const SzAnyType * type;  // non-owning; points into SzTypeStorage::nodes
+  bool is_key;
+  uint32_t native_offset;  // byte offset of this field in the native C/C++ struct
+  SzMemberCache cache;     // precomputed fast-path info (set during stamp pass)
+};
+
+struct SzStruct
+{
+  bool has_keys;
+  bool is_self_contained;
+  bool is_fixed = false;       // true if all Sample fields have fixed CDR size
+  bool alignment_invariant = false;  // true if fixed CDR size is the same at every starting alignment
+  size_t first_field_align = 1;  // CDR alignment of the first Sample field
+  size_t max_field_align = 1;    // maximum CDR alignment of any Sample field
+  size_t fixed_cdr_size = 0;  // valid only when is_fixed; CDR bytes of all Sample fields (from offset 0)
+  size_t native_size = 0;     // sizeof() the native C/C++ struct
+  std::span<const SzMember> members;
+};
+
+// Flat arena owning all SzAnyType nodes and SzMember entries for an entire
+// message type tree.  Both vectors are pre-reserved so that pointers / spans
+// into them remain stable after construction.
+struct SzTypeStorage
+{
+  std::vector<SzAnyType> nodes;
+  std::vector<SzMember> all_members;
+};
+
+struct SzArray
+{
+  const SzAnyType * element;  // non-owning; owned by enclosing SzStruct
+  size_t count;
+  size_t fixed_stride = 0;   // non-zero if element is fixed-size: CDR bytes per element
+  size_t native_elem_stride = 0;  // sizeof element in native memory
+};
+
+// rosidl C sequence: { T* data; size_t size; size_t capacity }
+struct SzCSequence
+{
+  const SzAnyType * element;  // non-owning; owned by enclosing SzStruct
+  uint32_t bound;             // UINT32_MAX means unbounded
+  size_t fixed_stride = 0;   // non-zero if element is fixed-size: CDR bytes per element
+  size_t native_elem_stride = 0;  // sizeof element in native memory
+};
+
+// C++ std::vector<T> (T != bool): { T* begin; T* end; T* cap }
+struct SzCppSequence
+{
+  const SzAnyType * element;  // non-owning; owned by enclosing SzStruct
+  uint32_t bound;             // UINT32_MAX means unbounded
+  size_t fixed_stride = 0;   // non-zero if element is fixed-size: CDR bytes per element
+  size_t native_elem_stride = 0;  // sizeof(T) in native memory
+};
+
+// rosidl C bool sequence: { bool* data; size_t size; size_t capacity }
+struct SzCBoolVector
+{
+  uint32_t bound;  // UINT32_MAX means unbounded
+};
+
+// C++ std::vector<bool>: bit-packed storage; use introspection size_function
+struct SzCppBoolVector
+{
+  uint32_t bound;  // UINT32_MAX means unbounded
+  size_t (* size_function)(const void *);  // always non-null; returns element count
+};
+
+// ---------------------------------------------------------------------------
+// Build a SzStruct from a MessageMembersVariant.
+// Returns the root struct and a storage arena owning all SzAnyType nodes.
+// ---------------------------------------------------------------------------
+std::pair<SzStruct, SzTypeStorage> make_sz_struct(MessageMembersVariant members);
+
+// ---------------------------------------------------------------------------
+// CDRSizer — implements the four BaseCDRWriter size methods without building
+// a full StructValueType.  Constructed from a MessageMembersVariant.
+// ---------------------------------------------------------------------------
+class CDRSizer
+{
+public:
+  explicit CDRSizer(MessageMembersVariant members, SampleOrRequest variant);
+
+  size_t get_serialized_size(const void * data, SampleOrKey what) const;
+  size_t get_serialized_size_estimate(const void * data, SampleOrKey what) const;
+  size_t get_min_serialized_size(SampleOrKey what) const;
+  size_t get_max_serialized_size(SampleOrKey what) const;
+
+private:
+  SzTypeStorage m_storage;
+  SzStruct m_root;
+  SampleOrRequest m_variant;
+  size_t m_min_data_size;
+  size_t m_min_key_size;
+  size_t m_max_data_size;
+  size_t m_max_key_size;
+};
+
+}  // namespace rmw_cyclonedds_cpp
+#endif  // SIZE_TYPE_SUPPORT_HPP_

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
@@ -112,7 +112,38 @@ std::unique_ptr<StructValueType> make_message_value_type(const rosidl_message_ty
   }
 }
 
-std::pair<std::unique_ptr<StructValueType>, std::unique_ptr<StructValueType>>
+MessageMembersVariant make_message_members_variant(const rosidl_message_type_support_t * mts)
+{
+  if (auto ts_c =
+    get_message_typesupport_handle(
+      mts,
+      TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::get_identifier()))
+  {
+    return static_cast<const MetaMessage<TypeGenerator::ROSIDL_C> *>(ts_c->data);
+  } else {
+    rcutils_error_string_t prev_error_string = rcutils_get_error_string();
+    rcutils_reset_error();
+
+    if (auto ts_cpp =
+      get_message_typesupport_handle(
+        mts,
+        TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
+    {
+      return static_cast<const MetaMessage<TypeGenerator::ROSIDL_Cpp> *>(ts_cpp->data);
+    } else {
+      rcutils_error_string_t error_string = rcutils_get_error_string();
+      rcutils_reset_error();
+
+      throw std::runtime_error(
+              std::string("Type support not from this implementation.  Got:\n") +
+              "    " + prev_error_string.str + "\n" +
+              "    " + error_string.str + "\n" +
+              "while fetching it");
+    }
+  }
+}
+
+std::pair<MessageMembersVariant, MessageMembersVariant>
 make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
 {
   if (auto tsc =
@@ -122,10 +153,7 @@ make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
   {
     auto typed =
       static_cast<const TypeGeneratorInfo<TypeGenerator::ROSIDL_C>::MetaService *>(tsc->data);
-    return {
-      std::make_unique<ROSIDLC_StructValueType>(typed->request_members_),
-      std::make_unique<ROSIDLC_StructValueType>(typed->response_members_)
-    };
+    return {typed->request_members_, typed->response_members_};
   } else {
     rcutils_error_string_t prev_error_string = rcutils_get_error_string();
     rcutils_reset_error();
@@ -135,12 +163,9 @@ make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
         svc_ts,
         TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::get_identifier()))
     {
-      auto typed =
-        static_cast<const TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::MetaService *>(tscpp->data);
-      return {
-        std::make_unique<ROSIDLCPP_StructValueType>(typed->request_members_),
-        std::make_unique<ROSIDLCPP_StructValueType>(typed->response_members_)
-      };
+      auto typed = static_cast<const TypeGeneratorInfo<TypeGenerator::ROSIDL_Cpp>::MetaService *>(
+        tscpp->data);
+      return {typed->request_members_, typed->response_members_};
     } else {
       rcutils_error_string_t error_string = rcutils_get_error_string();
       rcutils_reset_error();
@@ -152,6 +177,18 @@ make_request_response_value_types(const rosidl_service_type_support_t * svc_ts)
               "while fetching it");
     }
   }
+}
+
+std::unique_ptr<StructValueType> make_struct_value_type(MessageMembersVariant members)
+{
+  return std::visit([](auto * m) -> std::unique_ptr<StructValueType> {
+      using MembersType = std::remove_const_t<std::remove_pointer_t<decltype(m)>>;
+      if constexpr (std::is_same_v<MembersType, MetaMessage<TypeGenerator::ROSIDL_C>>) {
+        return std::make_unique<ROSIDLC_StructValueType>(m);
+      } else {
+        return std::make_unique<ROSIDLCPP_StructValueType>(m);
+      }
+    }, members);
 }
 
 ROSIDLC_StructValueType::ROSIDLC_StructValueType(

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -168,6 +168,37 @@ enum class ROSIDL_TypeKind : uint8_t
 enum class SampleOrKey { Sample, Key };
 enum class SampleOrRequest { Sample, Request };
 
+// ---------------------------------------------------------------------------
+// Count how many type-tree nodes and member entries a message type will need.
+// Shared by Sz / Ser / Deser builders so they can reserve() storage up front.
+// ---------------------------------------------------------------------------
+struct TypeTreeCounts
+{
+  size_t nodes = 0;    // number of *AnyType objects
+  size_t members = 0;  // total number of *Member entries across all structs
+};
+
+template<typename MetaMembers>
+TypeTreeCounts count_type_tree(const MetaMembers * impl)
+{
+  TypeTreeCounts c;
+  for (uint32_t i = 0; i < impl->member_count_; ++i) {
+    const auto & m = impl->members_[i];
+    c.nodes += 1;    // element node
+    c.members += 1;  // member entry
+    if (m.is_array_) {
+      c.nodes += 1;  // array / sequence / bool-vector wrapper
+    }
+    if (ROSIDL_TypeKind(m.type_id_) == ROSIDL_TypeKind::MESSAGE) {
+      auto sub = count_type_tree(
+        static_cast<const MetaMembers *>(m.members_->data));
+      c.nodes += sub.nodes + 1;    // +1 for the sub-struct node itself
+      c.members += sub.members;
+    }
+  }
+  return c;
+}
+
 class StructValueType;
 std::unique_ptr<StructValueType> make_message_value_type(const rosidl_message_type_support_t * mts);
 MessageMembersVariant make_message_members_variant(const rosidl_message_type_support_t * mts);

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 #include <stdexcept>
 
@@ -120,6 +121,11 @@ using MetaMember = typename TypeGeneratorInfo<g>::MetaMember;
 template<TypeGenerator g>
 using MetaService = typename TypeGeneratorInfo<g>::MetaService;
 
+using MessageMembersVariant = std::variant<
+  const MetaMessage<TypeGenerator::ROSIDL_C> *,
+  const MetaMessage<TypeGenerator::ROSIDL_Cpp> *
+>;
+
 namespace tsi_enum = rosidl_typesupport_introspection_cpp;
 
 // these are shared between c and cpp
@@ -148,9 +154,10 @@ enum class ROSIDL_TypeKind : uint8_t
 
 class StructValueType;
 std::unique_ptr<StructValueType> make_message_value_type(const rosidl_message_type_support_t * mts);
+MessageMembersVariant make_message_members_variant(const rosidl_message_type_support_t * mts);
 
-std::pair<std::unique_ptr<StructValueType>, std::unique_ptr<StructValueType>>
-make_request_response_value_types(const rosidl_service_type_support_t * svc);
+
+std::unique_ptr<StructValueType> make_struct_value_type(MessageMembersVariant members);
 
 enum class EValueType
 {

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -15,6 +15,7 @@
 #define TYPESUPPORT2_HPP_
 
 #include <cassert>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <string>
@@ -22,6 +23,18 @@
 #include <variant>
 #include <vector>
 #include <stdexcept>
+
+typedef struct cdds_request_header
+{
+  uint64_t guid;
+  int64_t seq;
+} cdds_request_header_t;
+
+typedef struct cdds_request_wrapper
+{
+  cdds_request_header_t header;
+  void * data;
+} cdds_request_wrapper_t;
 
 #include "rosidl_runtime_c/string_functions.h"
 #include "rosidl_runtime_c/u16string_functions.h"
@@ -151,6 +164,9 @@ enum class ROSIDL_TypeKind : uint8_t
   MESSAGE = tsi_enum::ROS_TYPE_MESSAGE,
 };
 
+
+enum class SampleOrKey { Sample, Key };
+enum class SampleOrRequest { Sample, Request };
 
 class StructValueType;
 std::unique_ptr<StructValueType> make_message_value_type(const rosidl_message_type_support_t * mts);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -62,7 +62,6 @@
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/impl/cpp/key_value.hpp"
 
-#include "TypeSupport2.hpp"
 
 #include "rmw_version_test.hpp"
 
@@ -1887,9 +1886,9 @@ extern "C" rmw_ret_t rmw_serialize(
   rmw_serialized_message_t * serialized_message)
 {
   try {
-    auto message_value_type = rmw_cyclonedds_cpp::make_message_value_type(type_support);
+    auto members = rmw_cyclonedds_cpp::make_message_members_variant(type_support);
     auto writer = rmw_cyclonedds_cpp::make_cdr_writer(
-      std::move(message_value_type),
+      members,
       rmw_cyclonedds_cpp::SampleOrRequest::Sample);
     auto size = writer->get_serialized_size(ros_message, rmw_cyclonedds_cpp::SampleOrKey::Sample);
     rmw_ret_t ret = rmw_serialized_message_resize(serialized_message, size);
@@ -1915,9 +1914,9 @@ extern "C" rmw_ret_t rmw_deserialize(
   void * ros_message)
 {
   try {
-    auto message_value_type = rmw_cyclonedds_cpp::make_message_value_type(type_support);
+    auto members = rmw_cyclonedds_cpp::make_message_members_variant(type_support);
     auto reader = rmw_cyclonedds_cpp::make_cdr_reader(
-      message_value_type.get(),
+      members,
       rmw_cyclonedds_cpp::SampleOrRequest::Sample);
     reader->deserialize(
       ros_message, serialized_message->buffer, serialized_message->buffer_length,
@@ -2484,14 +2483,15 @@ static CddsPublisher * create_cdds_publisher(
 
   std::string fqtopic_name = make_fqtopic(ROS_TOPIC_PREFIX, topic_name, "", qos_policies);
   const std::string type_name = get_message_type_name(type_support);
-  auto message_type_support = rmw_cyclonedds_cpp::make_message_value_type(type_supports);
-  const bool is_self_contained = message_type_support->is_self_contained();
-  const size_t sample_size = message_type_support->sizeof_type();
+  auto message_members = rmw_cyclonedds_cpp::make_message_members_variant(type_supports);
+  auto message_type_info = rmw_cyclonedds_cpp::make_struct_value_type(message_members);
+  const bool is_self_contained = message_type_info->is_self_contained();
+  const size_t sample_size = message_type_info->sizeof_type();
 
   auto sertype = create_sertype(
     type_name,
     false,
-    std::move(message_type_support));
+    message_members);
   create_msg_dds_dynamic_type(
     type_support->typesupport_identifier, type_support->data, dds_ppant,
     sertype);
@@ -2983,13 +2983,14 @@ static CddsSubscription * create_cdds_subscription(
 
   std::string fqtopic_name = make_fqtopic(ROS_TOPIC_PREFIX, topic_name, "", qos_policies);
   const std::string type_name = get_message_type_name(type_support);
-  auto message_type_support = rmw_cyclonedds_cpp::make_message_value_type(type_supports);
-  bool is_self_contained = message_type_support->is_self_contained();
+  auto message_members = rmw_cyclonedds_cpp::make_message_members_variant(type_supports);
+  auto message_type_info = rmw_cyclonedds_cpp::make_struct_value_type(message_members);
+  bool is_self_contained = message_type_info->is_self_contained();
 
   auto sertype = create_sertype(
     type_name,
     false,
-    std::move(message_type_support));
+    message_members);
   create_msg_dds_dynamic_type(
     type_support->typesupport_identifier, type_support->data, dds_ppant,
     sertype);
@@ -5121,16 +5122,15 @@ static rmw_ret_t rmw_init_cs(
   const rosidl_type_hash_t * ser_type_hash;
   std::string ser_typehash_str;
 
-  std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> pub_msg_ts, sub_msg_ts;
   struct sertype_rmw * pub_st, * sub_st;
 
   dds_listener_t * listener = dds_create_listener(cb_data);
   dds_lset_data_available_arg(listener, dds_listener_callback, cb_data, false);
 
-  if (is_service) {
-    std::tie(sub_msg_ts, pub_msg_ts) =
-      rmw_cyclonedds_cpp::make_request_response_value_types(type_supports);
+  auto [req_members, res_members] = rmw_cyclonedds_cpp::make_request_response_value_types(
+    type_supports);
 
+  if (is_service) {
     sub_type_hash = type_supports->request_typesupport->get_type_hash_func(
       type_supports->request_typesupport);
     pub_type_hash = type_supports->response_typesupport->get_type_hash_func(
@@ -5142,21 +5142,18 @@ static rmw_ret_t rmw_init_cs(
     pub_st = create_sertype(
       response_type_name,
       true,
-      std::move(pub_msg_ts));
+      res_members);
     create_res_dds_dynamic_type(
       type_support->typesupport_identifier, type_support->data,
       node->context->impl->ppant, pub_st);
     sub_st = create_sertype(
       request_type_name,
       true,
-      std::move(sub_msg_ts));
+      req_members);
     create_req_dds_dynamic_type(
       type_support->typesupport_identifier, type_support->data,
       node->context->impl->ppant, sub_st);
   } else {
-    std::tie(pub_msg_ts, sub_msg_ts) =
-      rmw_cyclonedds_cpp::make_request_response_value_types(type_supports);
-
     pub_type_hash = type_supports->request_typesupport->get_type_hash_func(
       type_supports->request_typesupport);
     sub_type_hash = type_supports->response_typesupport->get_type_hash_func(
@@ -5168,14 +5165,14 @@ static rmw_ret_t rmw_init_cs(
     pub_st = create_sertype(
       request_type_name,
       true,
-      std::move(pub_msg_ts));
+      req_members);
     create_req_dds_dynamic_type(
       type_support->typesupport_identifier, type_support->data,
       node->context->impl->ppant, pub_st);
     sub_st = create_sertype(
       response_type_name,
       true,
-      std::move(sub_msg_ts));
+      res_members);
     create_res_dds_dynamic_type(
       type_support->typesupport_identifier, type_support->data,
       node->context->impl->ppant, sub_st);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1889,7 +1889,7 @@ extern "C" rmw_ret_t rmw_serialize(
   try {
     auto message_value_type = rmw_cyclonedds_cpp::make_message_value_type(type_support);
     auto writer = rmw_cyclonedds_cpp::make_cdr_writer(
-      message_value_type.get(),
+      std::move(message_value_type),
       rmw_cyclonedds_cpp::SampleOrRequest::Sample);
     auto size = writer->get_serialized_size(ros_message, rmw_cyclonedds_cpp::SampleOrKey::Sample);
     rmw_ret_t ret = rmw_serialized_message_resize(serialized_message, size);

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -132,7 +132,7 @@ static void serdata_rmw_set_key_from_ser(serdata_rmw * d)
   auto type = static_cast<const struct sertype_rmw *>(d->type);
   if (type_contains_keys(type)) {
     try {
-      std::vector<byte> key;
+      std::vector<std::byte> key;
       type->cdr_reader->extractkey(
         key, d->data(), d->size(),
         (d->kind ==
@@ -582,7 +582,7 @@ static void serdata_rmw_get_keyhash(
   auto type = static_cast<const sertype_rmw *>(d->type);
   std::memset(buf, 0, sizeof(*buf));
   if (type_contains_keys(d->type)) {
-    std::vector<byte> key_be;
+    std::vector<std::byte> key_be;
     type->cdr_reader->extractkey_be(
       key_be, d->key(), d->keysize(),
       rmw_cyclonedds_cpp::SampleOrKey::Key);

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -683,7 +683,7 @@ bool sertype_rmw_equal(
   if (a->is_request_header != b->is_request_header) {
     return false;
   }
-  if (a->message_type->type_generator() != b->message_type->type_generator()) {
+  if (a->cdr_writer->type_generator() != b->cdr_writer->type_generator()) {
     return false;
   }
   return true;
@@ -695,8 +695,8 @@ uint32_t sertype_rmw_hash(const struct ddsi_sertype * tpcmn)
   uint32_t h2 = static_cast<uint32_t>(std::hash<bool>{}(tp->is_request_header));
   // FIXME: there's got to be an easier way
   auto gen =
-    static_cast<std::underlying_type<decltype(tp->message_type->type_generator())>::type>(tp->
-    message_type->type_generator());
+    static_cast<std::underlying_type<decltype(tp->cdr_writer->type_generator())>::type>(tp->
+    cdr_writer->type_generator());
   uint32_t h1 = static_cast<uint32_t>(std::hash<decltype(gen)>{}(gen));
   return h1 ^ h2;
 }
@@ -891,12 +891,12 @@ struct sertype_rmw * create_sertype(
 #endif  // DDS_HAS_SHM
 #endif  // CDDS_VERSION > CDDS_VERSION_0_10
   st->is_request_header = is_request_header;
-  st->message_type = std::move(message_type);
   const auto variant =
     is_request_header ? rmw_cyclonedds_cpp::SampleOrRequest::Request :
     rmw_cyclonedds_cpp::SampleOrRequest::Sample;
-  st->cdr_writer = rmw_cyclonedds_cpp::make_cdr_writer(st->message_type.get(), variant);
-  st->cdr_reader = rmw_cyclonedds_cpp::make_cdr_reader(st->message_type.get(), variant);
+  const auto * raw_type = message_type.get();
+  st->cdr_writer = rmw_cyclonedds_cpp::make_cdr_writer(std::move(message_type), variant);
+  st->cdr_reader = rmw_cyclonedds_cpp::make_cdr_reader(raw_type, variant);
 
   return st;
 }

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -852,8 +852,9 @@ static const struct ddsi_sertype_ops sertype_rmw_ops = {
 struct sertype_rmw * create_sertype(
   const std::string type_name,
   bool is_request_header,
-  std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type)
+  rmw_cyclonedds_cpp::MessageMembersVariant members)
 {
+  auto message_type = rmw_cyclonedds_cpp::make_struct_value_type(members);
   struct sertype_rmw * st = new struct sertype_rmw;
   const uint32_t sample_size = message_type->sizeof_type();
   const bool is_self_contained = message_type->is_self_contained();
@@ -894,9 +895,8 @@ struct sertype_rmw * create_sertype(
   const auto variant =
     is_request_header ? rmw_cyclonedds_cpp::SampleOrRequest::Request :
     rmw_cyclonedds_cpp::SampleOrRequest::Sample;
-  const auto * raw_type = message_type.get();
-  st->cdr_writer = rmw_cyclonedds_cpp::make_cdr_writer(std::move(message_type), variant);
-  st->cdr_reader = rmw_cyclonedds_cpp::make_cdr_reader(raw_type, variant);
+  st->cdr_writer = rmw_cyclonedds_cpp::make_cdr_writer(members, variant);
+  st->cdr_reader = rmw_cyclonedds_cpp::make_cdr_reader(members, variant);
 
   return st;
 }

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -85,7 +85,7 @@ typedef struct cdds_request_wrapper
 struct sertype_rmw * create_sertype(
   const std::string type_name,
   bool is_request_header,
-  std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type_support);
+  rmw_cyclonedds_cpp::MessageMembersVariant members);
 
 struct ddsi_serdata * serdata_rmw_from_serialized_message(
   const struct ddsi_sertype * typecmn,

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -39,7 +39,6 @@ class BaseCDRReader;
 struct sertype_rmw : ddsi_sertype
 {
   bool is_request_header;
-  std::unique_ptr<rmw_cyclonedds_cpp::StructValueType> message_type;
   std::unique_ptr<const rmw_cyclonedds_cpp::BaseCDRWriter> cdr_writer;
   std::unique_ptr<const rmw_cyclonedds_cpp::BaseCDRReader> cdr_reader;
   bool is_fixed;

--- a/rmw_cyclonedds_cpp/src/serdata.hpp
+++ b/rmw_cyclonedds_cpp/src/serdata.hpp
@@ -70,18 +70,6 @@ public:
   void set_key(size_t size, const void * key);
 };
 
-typedef struct cdds_request_header
-{
-  uint64_t guid;
-  int64_t seq;
-} cdds_request_header_t;
-
-typedef struct cdds_request_wrapper
-{
-  cdds_request_header_t header;
-  void * data;
-} cdds_request_wrapper_t;
-
 struct sertype_rmw * create_sertype(
   const std::string type_name,
   bool is_request_header,

--- a/rmw_cyclonedds_cpp/test/benchmark_size_computation.cpp
+++ b/rmw_cyclonedds_cpp/test/benchmark_size_computation.cpp
@@ -318,6 +318,140 @@ static void BM_OldImpl_Deserialize(benchmark::State & state)
 BENCHMARK(BM_NewImpl_Deserialize);
 BENCHMARK(BM_OldImpl_Deserialize);
 
+// ---------------------------------------------------------------------------
+// Single Marker serialize/deserialize benchmarks
+// Each Marker has kPointsPerMarker points and colors.
+// ---------------------------------------------------------------------------
+static std::array<visualization_msgs::msg::Marker, kNumMessages> g_markers;
+
+static void init_markers()
+{
+  static bool done = false;
+  if (done) {return;}
+  done = true;
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    auto & m = g_markers[i];
+    m.header.frame_id = "benchmark_frame";
+    m.ns = "benchmark_ns";
+    m.id = static_cast<int32_t>(i);
+    m.type = visualization_msgs::msg::Marker::POINTS;
+    m.action = visualization_msgs::msg::Marker::ADD;
+    m.text = "some label text";
+    m.mesh_resource = "package://some_pkg/meshes/model.dae";
+    m.points.resize(kPointsPerMarker);
+    m.colors.resize(kPointsPerMarker);
+    for (size_t k = 0; k < kPointsPerMarker; ++k) {
+      m.points[k].x = static_cast<double>(k);
+      m.points[k].y = static_cast<double>(k) * 0.5;
+      m.points[k].z = 0.0;
+      m.colors[k].r = 1.0f;
+      m.colors[k].g = 0.5f;
+      m.colors[k].b = 0.0f;
+      m.colors[k].a = 1.0f;
+    }
+  }
+}
+
+static std::vector<std::vector<unsigned char>> g_serialized_markers;
+
+static void init_serialized_markers()
+{
+  if (!g_serialized_markers.empty()) {
+    return;
+  }
+  init_markers();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  g_serialized_markers.resize(kNumMessages);
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    size_t sz = serializer.get_serialized_size(&g_markers[i], SampleOrKey::Sample);
+    g_serialized_markers[i].resize(sz);
+    serializer.serialize(g_serialized_markers[i].data(), &g_markers[i], SampleOrKey::Sample);
+  }
+}
+
+static void BM_Marker_Serialize_Old(benchmark::State & state)
+{
+  init_markers();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+
+  size_t max_size = writer->get_max_serialized_size(SampleOrKey::Sample);
+  if (max_size == SIZE_MAX) {
+    max_size = 1024 * 1024;
+  }
+  std::vector<unsigned char> buf(max_size);
+
+  size_t idx = 0;
+  for (auto _ : state) {
+    writer->serialize(buf.data(), &g_markers[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_Marker_Serialize(benchmark::State & state)
+{
+  init_markers();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+
+  size_t max_size = serializer.get_max_serialized_size(SampleOrKey::Sample);
+  if (max_size == SIZE_MAX) {
+    max_size = 1024 * 1024;
+  }
+  std::vector<unsigned char> buf(max_size);
+
+  size_t idx = 0;
+  for (auto _ : state) {
+    serializer.serialize(buf.data(), &g_markers[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_Marker_Deserialize_Old(benchmark::State & state)
+{
+  init_serialized_markers();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  auto reader = make_cdr_reader_old(members, SampleOrRequest::Sample);
+
+  visualization_msgs::msg::Marker msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = g_serialized_markers[idx];
+    reader->deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(msg.points.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_Marker_Deserialize(benchmark::State & state)
+{
+  init_serialized_markers();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  visualization_msgs::msg::Marker msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = g_serialized_markers[idx];
+    deserializer.deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(msg.points.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+BENCHMARK(BM_Marker_Serialize_Old);
+BENCHMARK(BM_Marker_Serialize);
+BENCHMARK(BM_Marker_Deserialize_Old);
+BENCHMARK(BM_Marker_Deserialize);
+
 // ===========================================================================
 // sensor_msgs benchmarks
 // ===========================================================================

--- a/rmw_cyclonedds_cpp/test/benchmark_size_computation.cpp
+++ b/rmw_cyclonedds_cpp/test/benchmark_size_computation.cpp
@@ -1,0 +1,584 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <benchmark/benchmark.h>
+
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "rosidl_typesupport_interface/macros.h"
+
+// std_msgs
+#include "std_msgs/msg/detail/bool__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/int32__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/string__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/header__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/float64_multi_array__rosidl_typesupport_introspection_cpp.hpp"
+
+// visualization_msgs
+#include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+#include "visualization_msgs/msg/detail/marker__rosidl_typesupport_introspection_cpp.hpp"
+#include "visualization_msgs/msg/detail/marker_array__rosidl_typesupport_introspection_cpp.hpp"
+
+// sensor_msgs
+#include "sensor_msgs/msg/point_cloud2.hpp"
+#include "sensor_msgs/msg/laser_scan.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "sensor_msgs/msg/point_field.hpp"
+#include "sensor_msgs/msg/detail/point_cloud2__rosidl_typesupport_introspection_cpp.hpp"
+#include "sensor_msgs/msg/detail/laser_scan__rosidl_typesupport_introspection_cpp.hpp"
+#include "sensor_msgs/msg/detail/image__rosidl_typesupport_introspection_cpp.hpp"
+
+#include "SizeTypeSupport.hpp"
+#include "SerTypeSupport.hpp"
+#include "DeserTypeSupport.hpp"
+#include "BaseCDRWriter.hpp"
+
+#define GET_TS(pkg, iface, name) \
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME( \
+    rosidl_typesupport_introspection_cpp, pkg, iface, name)()
+
+using namespace rmw_cyclonedds_cpp;
+
+// ---------------------------------------------------------------------------
+// Pre-allocated array of heavy MarkerArray messages used by the data benchmarks.
+// Each contains 20 Markers with 200 points, 200 colors, and non-empty strings.
+// ---------------------------------------------------------------------------
+static constexpr size_t kNumMessages = 32;
+static constexpr size_t kMarkersPerArray = 20;
+static constexpr size_t kPointsPerMarker = 200;
+
+static std::array<visualization_msgs::msg::MarkerArray, kNumMessages> g_marker_arrays;
+
+static void init_marker_arrays()
+{
+  static bool done = false;
+  if (done) {return;}
+  done = true;
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    auto & ma = g_marker_arrays[i];
+    ma.markers.resize(kMarkersPerArray);
+    for (size_t j = 0; j < kMarkersPerArray; ++j) {
+      auto & m = ma.markers[j];
+      m.header.frame_id = "benchmark_frame";
+      m.ns = "benchmark_ns";
+      m.id = static_cast<int32_t>(i * kMarkersPerArray + j);
+      m.type = visualization_msgs::msg::Marker::POINTS;
+      m.action = visualization_msgs::msg::Marker::ADD;
+      m.text = "some label text";
+      m.mesh_resource = "package://some_pkg/meshes/model.dae";
+      m.points.resize(kPointsPerMarker);
+      m.colors.resize(kPointsPerMarker);
+      for (size_t k = 0; k < kPointsPerMarker; ++k) {
+        m.points[k].x = static_cast<double>(k);
+        m.points[k].y = static_cast<double>(k) * 0.5;
+        m.points[k].z = 0.0;
+        m.colors[k].r = 1.0f;
+        m.colors[k].g = 0.5f;
+        m.colors[k].b = 0.0f;
+        m.colors[k].a = 1.0f;
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Size-bound benchmarks (construction cost only — no data pointer needed).
+// Construction is outside the loop; we benchmark min/max queries.
+// ---------------------------------------------------------------------------
+static void BM_OldImpl_SizeBound(
+  benchmark::State & state,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(writer->get_min_serialized_size(SampleOrKey::Sample));
+    benchmark::DoNotOptimize(writer->get_max_serialized_size(SampleOrKey::Sample));
+  }
+}
+
+static void BM_NewImpl_SizeBound(
+  benchmark::State & state,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(sizer.get_min_serialized_size(SampleOrKey::Sample));
+    benchmark::DoNotOptimize(sizer.get_max_serialized_size(SampleOrKey::Sample));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_serialized_size benchmarks — cycles through the pre-allocated array.
+// ---------------------------------------------------------------------------
+static void BM_OldImpl_SerializedSize(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      writer->get_serialized_size(&g_marker_arrays[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_NewImpl_SerializedSize(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      sizer.get_serialized_size(&g_marker_arrays[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// get_serialized_size_estimate benchmarks
+// ---------------------------------------------------------------------------
+static void BM_OldImpl_SerializedSizeEstimate(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      writer->get_serialized_size_estimate(&g_marker_arrays[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_NewImpl_SerializedSizeEstimate(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      sizer.get_serialized_size_estimate(&g_marker_arrays[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Register benchmarks
+// ---------------------------------------------------------------------------
+
+#define REGISTER_BOUND(label, pkg, iface, name) \
+  BENCHMARK_CAPTURE(BM_OldImpl_SizeBound, label, GET_TS(pkg, iface, name)); \
+  BENCHMARK_CAPTURE(BM_NewImpl_SizeBound, label, GET_TS(pkg, iface, name));
+
+REGISTER_BOUND(Bool,              std_msgs,           msg, Bool)
+REGISTER_BOUND(Int32,             std_msgs,           msg, Int32)
+REGISTER_BOUND(String,            std_msgs,           msg, String)
+REGISTER_BOUND(Header,            std_msgs,           msg, Header)
+REGISTER_BOUND(Float64MultiArray, std_msgs,           msg, Float64MultiArray)
+REGISTER_BOUND(Marker,            visualization_msgs, msg, Marker)
+REGISTER_BOUND(MarkerArray,       visualization_msgs, msg, MarkerArray)
+REGISTER_BOUND(PointCloud2,       sensor_msgs,        msg, PointCloud2)
+REGISTER_BOUND(LaserScan,         sensor_msgs,        msg, LaserScan)
+REGISTER_BOUND(Image,             sensor_msgs,        msg, Image)
+
+BENCHMARK(BM_OldImpl_SerializedSize);
+BENCHMARK(BM_NewImpl_SerializedSize);
+BENCHMARK(BM_OldImpl_SerializedSizeEstimate);
+BENCHMARK(BM_NewImpl_SerializedSizeEstimate);
+
+// ---------------------------------------------------------------------------
+// serialize() benchmarks — pre-allocate output buffer outside loop
+// ---------------------------------------------------------------------------
+static void BM_OldImpl_Serialize(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+
+  // Allocate worst-case buffer
+  size_t max_size = writer->get_max_serialized_size(SampleOrKey::Sample);
+  if (max_size == SIZE_MAX) {
+    max_size = 16 * 1024 * 1024;  // 16 MB fallback for unbounded messages
+  }
+  std::vector<unsigned char> buf(max_size);
+
+  size_t idx = 0;
+  for (auto _ : state) {
+    writer->serialize(buf.data(), &g_marker_arrays[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_NewImpl_Serialize(benchmark::State & state)
+{
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+
+  size_t max_size = serializer.get_max_serialized_size(SampleOrKey::Sample);
+  if (max_size == SIZE_MAX) {
+    max_size = 16 * 1024 * 1024;
+  }
+  std::vector<unsigned char> buf(max_size);
+
+  size_t idx = 0;
+  for (auto _ : state) {
+    serializer.serialize(buf.data(), &g_marker_arrays[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+BENCHMARK(BM_OldImpl_Serialize);
+BENCHMARK(BM_NewImpl_Serialize);
+
+// ---------------------------------------------------------------------------
+// deserialize() benchmarks — pre-serialize all messages, then time reading
+// ---------------------------------------------------------------------------
+static std::vector<std::vector<unsigned char>> g_serialized_marker_arrays;
+
+static void init_serialized_marker_arrays()
+{
+  if (!g_serialized_marker_arrays.empty()) {
+    return;
+  }
+  init_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  g_serialized_marker_arrays.resize(kNumMessages);
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    size_t sz = serializer.get_serialized_size(&g_marker_arrays[i], SampleOrKey::Sample);
+    g_serialized_marker_arrays[i].resize(sz);
+    serializer.serialize(
+      g_serialized_marker_arrays[i].data(), &g_marker_arrays[i], SampleOrKey::Sample);
+  }
+}
+
+static void BM_NewImpl_Deserialize(benchmark::State & state)
+{
+  init_serialized_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  visualization_msgs::msg::MarkerArray msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = g_serialized_marker_arrays[idx];
+    deserializer.deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(msg.markers.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+static void BM_OldImpl_Deserialize(benchmark::State & state)
+{
+  init_serialized_marker_arrays();
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  auto reader = make_cdr_reader_old(members, SampleOrRequest::Sample);
+
+  visualization_msgs::msg::MarkerArray msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = g_serialized_marker_arrays[idx];
+    reader->deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(msg.markers.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+BENCHMARK(BM_NewImpl_Deserialize);
+BENCHMARK(BM_OldImpl_Deserialize);
+
+// ===========================================================================
+// sensor_msgs benchmarks
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// Message pools: 32 pre-populated instances of each type
+// ---------------------------------------------------------------------------
+static constexpr uint32_t kPC2Width = 640;   // points per row
+static constexpr uint32_t kPC2Height = 480;  // rows (VGA-sized organized cloud)
+static constexpr uint32_t kPC2PointStep = 32; // XYZ + intensity + ring (typical Velodyne)
+static constexpr uint32_t kLaserBeams = 1080; // typical 270° / 0.25° scan
+static constexpr uint32_t kImageWidth = 1280;
+static constexpr uint32_t kImageHeight = 720;
+static constexpr uint32_t kImageChannels = 3; // BGR8
+
+static std::array<sensor_msgs::msg::PointCloud2, kNumMessages> g_pointclouds;
+static std::array<sensor_msgs::msg::LaserScan,   kNumMessages> g_laser_scans;
+static std::array<sensor_msgs::msg::Image,       kNumMessages> g_images;
+
+static void init_sensor_msgs()
+{
+  static bool done = false;
+  if (done) {return;}
+  done = true;
+
+  // PointCloud2: kPC2Width * kPC2Height points, each kPC2PointStep bytes
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    auto & pc = g_pointclouds[i];
+    pc.header.frame_id = "velodyne";
+    pc.height = kPC2Height;
+    pc.width  = kPC2Width;
+    pc.point_step = kPC2PointStep;
+    pc.row_step   = kPC2Width * kPC2PointStep;
+    pc.is_bigendian = false;
+    pc.is_dense = true;
+    // 4 named fields: x, y, z, intensity
+    const char * names[] = {"x", "y", "z", "intensity"};
+    const uint8_t datatypes[] = {7, 7, 7, 7};  // FLOAT32 = 7
+    const uint32_t offsets[] = {0, 4, 8, 12};
+    pc.fields.resize(4);
+    for (int f = 0; f < 4; ++f) {
+      pc.fields[f].name     = names[f];
+      pc.fields[f].offset   = offsets[f];
+      pc.fields[f].datatype = datatypes[f];
+      pc.fields[f].count    = 1;
+    }
+    pc.data.resize(static_cast<size_t>(kPC2Height) * kPC2Width * kPC2PointStep,
+      static_cast<uint8_t>(i & 0xFF));
+  }
+
+  // LaserScan: kLaserBeams range + intensity readings
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    auto & ls = g_laser_scans[i];
+    ls.header.frame_id = "laser";
+    ls.angle_min      = -2.356194f;  // -135°
+    ls.angle_max      =  2.356194f;  // +135°
+    ls.angle_increment = static_cast<float>(4.712389 / (kLaserBeams - 1));
+    ls.time_increment  = 0.0f;
+    ls.scan_time       = 0.1f;
+    ls.range_min       = 0.05f;
+    ls.range_max       = 30.0f;
+    ls.ranges.resize(kLaserBeams, 5.0f);
+    ls.intensities.resize(kLaserBeams, 100.0f);
+  }
+
+  // Image: kImageWidth × kImageHeight BGR8
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    auto & img = g_images[i];
+    img.header.frame_id = "camera";
+    img.height   = kImageHeight;
+    img.width    = kImageWidth;
+    img.encoding = "bgr8";
+    img.is_bigendian = 0;
+    img.step     = kImageWidth * kImageChannels;
+    img.data.resize(
+      static_cast<size_t>(kImageHeight) * kImageWidth * kImageChannels,
+      static_cast<uint8_t>(i & 0xFF));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Generic size / serialize / deserialize helpers templated on message type
+// ---------------------------------------------------------------------------
+template<typename MsgT>
+static void BM_SensorMsg_SerializedSize_Old(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      writer->get_serialized_size(&pool[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+template<typename MsgT>
+static void BM_SensorMsg_Serialize_Old(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  size_t max_size = writer->get_max_serialized_size(SampleOrKey::Sample);
+  if (max_size == SIZE_MAX) {
+    max_size = 16 * 1024 * 1024;
+  }
+  std::vector<unsigned char> buf(max_size);
+  size_t idx = 0;
+  for (auto _ : state) {
+    writer->serialize(buf.data(), &pool[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+  state.SetBytesProcessed(
+    static_cast<int64_t>(state.iterations()) *
+    static_cast<int64_t>(writer->get_serialized_size(&pool[0], SampleOrKey::Sample)));
+}
+
+template<typename MsgT>
+static void BM_SensorMsg_Deserialize_Old(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  auto writer = make_cdr_writer_old(members, SampleOrRequest::Sample);
+  auto reader = make_cdr_reader_old(members, SampleOrRequest::Sample);
+
+  std::vector<std::vector<unsigned char>> bufs(kNumMessages);
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    size_t sz = writer->get_serialized_size(&pool[i], SampleOrKey::Sample);
+    bufs[i].resize(sz);
+    writer->serialize(bufs[i].data(), &pool[i], SampleOrKey::Sample);
+  }
+
+  MsgT msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = bufs[idx];
+    reader->deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(&msg);
+    idx = (idx + 1) % kNumMessages;
+  }
+  state.SetBytesProcessed(
+    static_cast<int64_t>(state.iterations()) *
+    static_cast<int64_t>(bufs[0].size()));
+}
+
+template<typename MsgT>
+static void BM_SensorMsg_SerializedSize(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  size_t idx = 0;
+  for (auto _ : state) {
+    benchmark::DoNotOptimize(
+      sizer.get_serialized_size(&pool[idx], SampleOrKey::Sample));
+    idx = (idx + 1) % kNumMessages;
+  }
+}
+
+template<typename MsgT>
+static void BM_SensorMsg_Serialize(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  // size off first element — all are the same size
+  size_t sz = serializer.get_serialized_size(&pool[0], SampleOrKey::Sample);
+  std::vector<unsigned char> buf(sz);
+  size_t idx = 0;
+  for (auto _ : state) {
+    serializer.serialize(buf.data(), &pool[idx], SampleOrKey::Sample);
+    benchmark::DoNotOptimize(buf.data());
+    idx = (idx + 1) % kNumMessages;
+  }
+  state.SetBytesProcessed(
+    static_cast<int64_t>(state.iterations()) * static_cast<int64_t>(sz));
+}
+
+template<typename MsgT>
+static void BM_SensorMsg_Deserialize(
+  benchmark::State & state,
+  std::array<MsgT, kNumMessages> & pool,
+  const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  std::vector<std::vector<unsigned char>> bufs(kNumMessages);
+  for (size_t i = 0; i < kNumMessages; ++i) {
+    size_t sz = serializer.get_serialized_size(&pool[i], SampleOrKey::Sample);
+    bufs[i].resize(sz);
+    serializer.serialize(bufs[i].data(), &pool[i], SampleOrKey::Sample);
+  }
+
+  MsgT msg;
+  size_t idx = 0;
+  for (auto _ : state) {
+    const auto & buf = bufs[idx];
+    deserializer.deserialize(&msg, buf.data(), buf.size(), SampleOrKey::Sample);
+    benchmark::DoNotOptimize(&msg);
+    idx = (idx + 1) % kNumMessages;
+  }
+  state.SetBytesProcessed(
+    static_cast<int64_t>(state.iterations()) *
+    static_cast<int64_t>(bufs[0].size()));
+}
+
+// Helper macro: register old+new sensor msg benchmarks for one message type.
+#define REGISTER_SENSOR(label, pool, pkg, iface, name) \
+  static void BM_ ## label ## _SerializedSize_Old(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_SerializedSize_Old(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  static void BM_ ## label ## _SerializedSize(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_SerializedSize(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  static void BM_ ## label ## _Serialize_Old(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_Serialize_Old(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  static void BM_ ## label ## _Serialize(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_Serialize(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  static void BM_ ## label ## _Deserialize_Old(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_Deserialize_Old(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  static void BM_ ## label ## _Deserialize(benchmark::State & state) \
+  { \
+    init_sensor_msgs(); \
+    BM_SensorMsg_Deserialize(state, pool, GET_TS(pkg, iface, name)); \
+  } \
+  BENCHMARK(BM_ ## label ## _SerializedSize_Old); \
+  BENCHMARK(BM_ ## label ## _SerializedSize); \
+  BENCHMARK(BM_ ## label ## _Serialize_Old); \
+  BENCHMARK(BM_ ## label ## _Serialize); \
+  BENCHMARK(BM_ ## label ## _Deserialize_Old); \
+  BENCHMARK(BM_ ## label ## _Deserialize);
+
+REGISTER_SENSOR(PointCloud2, g_pointclouds, sensor_msgs, msg, PointCloud2)
+REGISTER_SENSOR(LaserScan,   g_laser_scans, sensor_msgs, msg, LaserScan)
+REGISTER_SENSOR(Image,       g_images,      sensor_msgs, msg, Image)
+
+BENCHMARK_MAIN();

--- a/rmw_cyclonedds_cpp/test/test_helpers.hpp
+++ b/rmw_cyclonedds_cpp/test/test_helpers.hpp
@@ -1,0 +1,241 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifndef TEST_HELPERS_HPP_
+#define TEST_HELPERS_HPP_
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <vector>
+
+#include "rosidl_typesupport_interface/macros.h"
+
+#include "SizeTypeSupport.hpp"
+#include "SerTypeSupport.hpp"
+#include "DeserTypeSupport.hpp"
+#include "Serialization.hpp"
+
+#define GET_TS(pkg, iface, name) \
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME( \
+    rosidl_typesupport_introspection_cpp, pkg, iface, name)()
+
+#define GET_TS_C(pkg, iface, name) \
+  ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME( \
+    rosidl_typesupport_introspection_c, pkg, iface, name)()
+
+using namespace rmw_cyclonedds_cpp;
+
+// ---------------------------------------------------------------------------
+// check_parity: CDRSizer min/max (Sample+Key) matches CDRWriter
+// ---------------------------------------------------------------------------
+inline void check_parity(
+  const rosidl_message_type_support_t * ts,
+  SampleOrRequest variant = SampleOrRequest::Sample)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, variant);
+  auto writer = make_cdr_writer(members, variant);
+
+  EXPECT_EQ(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample))
+    << "min Sample mismatch";
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample))
+    << "max Sample mismatch";
+  EXPECT_EQ(
+    sizer.get_min_serialized_size(SampleOrKey::Key),
+    writer->get_min_serialized_size(SampleOrKey::Key))
+    << "min Key mismatch";
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Key),
+    writer->get_max_serialized_size(SampleOrKey::Key))
+    << "max Key mismatch";
+}
+
+// ---------------------------------------------------------------------------
+// check_parity_with_data: CDRSizer serialized size / estimate matches CDRWriter
+// ---------------------------------------------------------------------------
+inline void check_parity_with_data(
+  const rosidl_message_type_support_t * ts,
+  const void * data,
+  SampleOrRequest variant = SampleOrRequest::Sample)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, variant);
+  auto writer = make_cdr_writer(members, variant);
+
+  EXPECT_EQ(
+    sizer.get_serialized_size(data, SampleOrKey::Sample),
+    writer->get_serialized_size(data, SampleOrKey::Sample))
+    << "get_serialized_size Sample mismatch";
+  EXPECT_EQ(
+    sizer.get_serialized_size(data, SampleOrKey::Key),
+    writer->get_serialized_size(data, SampleOrKey::Key))
+    << "get_serialized_size Key mismatch";
+
+  EXPECT_GE(
+    sizer.get_serialized_size_estimate(data, SampleOrKey::Sample),
+    sizer.get_serialized_size(data, SampleOrKey::Sample))
+    << "estimate < actual (Sample)";
+  EXPECT_GE(
+    sizer.get_serialized_size_estimate(data, SampleOrKey::Key),
+    sizer.get_serialized_size(data, SampleOrKey::Key))
+    << "estimate < actual (Key)";
+
+  EXPECT_EQ(
+    sizer.get_serialized_size_estimate(data, SampleOrKey::Sample),
+    writer->get_serialized_size_estimate(data, SampleOrKey::Sample))
+    << "get_serialized_size_estimate Sample mismatch";
+}
+
+// ---------------------------------------------------------------------------
+// check_serializer_roundtrip: CDRSerializer bytes match CDRWriter bytes
+// ---------------------------------------------------------------------------
+inline void check_serializer_roundtrip(
+  const rosidl_message_type_support_t * ts,
+  const void * data,
+  SampleOrRequest variant = SampleOrRequest::Sample)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, variant);
+  auto writer = make_cdr_writer(members, variant);
+
+  size_t cdr_size = writer->get_serialized_size(data, SampleOrKey::Sample);
+  ASSERT_GT(cdr_size, 0u);
+
+  std::vector<unsigned char> buf_new(cdr_size, 0);
+  std::vector<unsigned char> buf_old(cdr_size, 0);
+  serializer.serialize(buf_new.data(), data, SampleOrKey::Sample);
+  writer->serialize(buf_old.data(), data, SampleOrKey::Sample);
+
+  EXPECT_EQ(buf_new, buf_old) << "CDRSerializer output differs from CDRWriter";
+}
+
+// ---------------------------------------------------------------------------
+// check_deserializer_roundtrip: serialize → deserialize → re-serialize = same
+// ---------------------------------------------------------------------------
+template<typename MsgT>
+inline void check_deserializer_roundtrip(
+  const rosidl_message_type_support_t * ts,
+  const MsgT & original,
+  SampleOrRequest variant = SampleOrRequest::Sample)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, variant);
+  CDRDeserializer deserializer(members, variant);
+
+  size_t cdr_size = serializer.get_serialized_size(&original, SampleOrKey::Sample);
+  ASSERT_GT(cdr_size, 0u);
+
+  std::vector<unsigned char> buf_orig(cdr_size, 0);
+  serializer.serialize(buf_orig.data(), &original, SampleOrKey::Sample);
+
+  MsgT restored{};
+  deserializer.deserialize(&restored, buf_orig.data(), cdr_size, SampleOrKey::Sample);
+
+  size_t cdr_size2 = serializer.get_serialized_size(&restored, SampleOrKey::Sample);
+  std::vector<unsigned char> buf_restored(cdr_size2, 0);
+  serializer.serialize(buf_restored.data(), &restored, SampleOrKey::Sample);
+
+  EXPECT_EQ(buf_orig, buf_restored) << "CDRDeserializer roundtrip: re-serialized bytes differ";
+}
+
+// ---------------------------------------------------------------------------
+// Key-specific helpers
+// ---------------------------------------------------------------------------
+
+inline void check_key_size_parity(const rosidl_message_type_support_t * ts)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+
+  EXPECT_EQ(
+    sizer.get_min_serialized_size(SampleOrKey::Key),
+    writer->get_min_serialized_size(SampleOrKey::Key))
+    << "Key min mismatch";
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Key),
+    writer->get_max_serialized_size(SampleOrKey::Key))
+    << "Key max mismatch";
+}
+
+template<typename MsgT>
+inline void check_key_serialize(
+  const rosidl_message_type_support_t * ts, const MsgT & msg)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+
+  size_t sz = writer->get_serialized_size(&msg, SampleOrKey::Key);
+  ASSERT_GT(sz, 0u);
+
+  std::vector<unsigned char> buf_new(sz, 0);
+  std::vector<unsigned char> buf_old(sz, 0);
+  serializer.serialize(buf_new.data(), &msg, SampleOrKey::Key);
+  writer->serialize(buf_old.data(), &msg, SampleOrKey::Key);
+
+  EXPECT_EQ(buf_new, buf_old) << "CDRSerializer Key output differs from CDRWriter";
+}
+
+template<typename MsgT>
+inline void check_extractkey(
+  const rosidl_message_type_support_t * ts, const MsgT & msg)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  size_t sample_sz = serializer.get_serialized_size(&msg, SampleOrKey::Sample);
+  ASSERT_GT(sample_sz, 0u);
+  std::vector<unsigned char> sample_buf(sample_sz, 0);
+  serializer.serialize(sample_buf.data(), &msg, SampleOrKey::Sample);
+
+  std::vector<std::byte> extracted;
+  deserializer.extractkey(extracted, sample_buf.data(), sample_sz, SampleOrKey::Sample);
+  ASSERT_FALSE(extracted.empty()) << "extractkey returned empty output";
+
+  size_t key_sz = serializer.get_serialized_size(&msg, SampleOrKey::Key);
+  std::vector<unsigned char> key_buf(key_sz, 0);
+  serializer.serialize(key_buf.data(), &msg, SampleOrKey::Key);
+
+  ASSERT_EQ(extracted.size(), key_buf.size()) << "extractkey size mismatch";
+  EXPECT_EQ(0, std::memcmp(extracted.data(), key_buf.data(), key_sz))
+    << "extractkey bytes differ from direct Key serialization";
+}
+
+template<typename MsgT>
+inline void check_extractkey_be(
+  const rosidl_message_type_support_t * ts, const MsgT & msg)
+{
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  size_t sample_sz = serializer.get_serialized_size(&msg, SampleOrKey::Sample);
+  std::vector<unsigned char> sample_buf(sample_sz, 0);
+  serializer.serialize(sample_buf.data(), &msg, SampleOrKey::Sample);
+
+  std::vector<std::byte> extracted_be;
+  deserializer.extractkey_be(
+    extracted_be, sample_buf.data(), sample_sz, SampleOrKey::Sample);
+  ASSERT_GE(extracted_be.size(), 4u);
+  EXPECT_EQ(static_cast<uint8_t>(extracted_be[1]), 0u)
+    << "extractkey_be header byte should indicate big-endian (0)";
+}
+
+#endif  // TEST_HELPERS_HPP_

--- a/rmw_cyclonedds_cpp/test/test_keyed_msgs.cpp
+++ b/rmw_cyclonedds_cpp/test/test_keyed_msgs.cpp
@@ -1,0 +1,159 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_helpers.hpp"
+
+#include "test_msgs/msg/keyed_long.hpp"
+#include "test_msgs/msg/keyed_string.hpp"
+#include "test_msgs/msg/complex_nested_key.hpp"
+#include "test_msgs/msg/detail/keyed_long__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/keyed_string__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/complex_nested_key__rosidl_typesupport_introspection_cpp.hpp"
+
+// ---------------------------------------------------------------------------
+// KeyedLong: @key int32, non-key int32
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, KeyedLong_KeySizeParity)
+{
+  check_key_size_parity(GET_TS(test_msgs, msg, KeyedLong));
+}
+
+TEST(SizeTypeSupportTest, KeyedLong_KeySizeAbsolute)
+{
+  // key = int32: 4-byte CDR header + 4-byte int32 = 8
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(test_msgs, msg, KeyedLong));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Key), 8u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Key), 8u);
+}
+
+TEST(SerializerTest, KeyedLong_KeySerialize)
+{
+  test_msgs::msg::KeyedLong msg;
+  msg.key = 42;
+  msg.value = 99;
+  check_key_serialize(GET_TS(test_msgs, msg, KeyedLong), msg);
+}
+
+TEST(DeserializerTest, KeyedLong_ExtractKey)
+{
+  test_msgs::msg::KeyedLong msg;
+  msg.key = 42;
+  msg.value = 99;
+  check_extractkey(GET_TS(test_msgs, msg, KeyedLong), msg);
+}
+
+TEST(DeserializerTest, KeyedLong_ExtractKeyBE)
+{
+  test_msgs::msg::KeyedLong msg;
+  msg.key = 42;
+  msg.value = 99;
+  check_extractkey_be(GET_TS(test_msgs, msg, KeyedLong), msg);
+}
+
+TEST(DeserializerTest, KeyedLong_KeyOnlyDeserialize)
+{
+  test_msgs::msg::KeyedLong msg;
+  msg.key = 1234;
+  msg.value = 5678;
+
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(test_msgs, msg, KeyedLong));
+  CDRSerializer serializer(members, SampleOrRequest::Sample);
+  CDRDeserializer deserializer(members, SampleOrRequest::Sample);
+
+  size_t key_sz = serializer.get_serialized_size(&msg, SampleOrKey::Key);
+  std::vector<unsigned char> key_buf(key_sz, 0);
+  serializer.serialize(key_buf.data(), &msg, SampleOrKey::Key);
+
+  test_msgs::msg::KeyedLong restored{};
+  deserializer.deserialize(&restored, key_buf.data(), key_sz, SampleOrKey::Key);
+  EXPECT_EQ(restored.key, msg.key);
+}
+
+// ---------------------------------------------------------------------------
+// KeyedString: @key string, non-key string
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, KeyedString_KeySizeParity)
+{
+  check_key_size_parity(GET_TS(test_msgs, msg, KeyedString));
+}
+
+TEST(SizeTypeSupportTest, KeyedString_KeyMinSizeUnbounded)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(test_msgs, msg, KeyedString));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Key), SIZE_MAX);
+}
+
+TEST(SerializerTest, KeyedString_KeySerialize)
+{
+  test_msgs::msg::KeyedString msg;
+  msg.key = "robot_1";
+  msg.value = "ignored_in_key";
+  check_key_serialize(GET_TS(test_msgs, msg, KeyedString), msg);
+}
+
+TEST(DeserializerTest, KeyedString_ExtractKey)
+{
+  test_msgs::msg::KeyedString msg;
+  msg.key = "robot_1";
+  msg.value = "ignored_in_key";
+  check_extractkey(GET_TS(test_msgs, msg, KeyedString), msg);
+}
+
+TEST(DeserializerTest, KeyedString_ExtractKeyBE)
+{
+  test_msgs::msg::KeyedString msg;
+  msg.key = "robot_1";
+  msg.value = "ignored_in_key";
+  check_extractkey_be(GET_TS(test_msgs, msg, KeyedString), msg);
+}
+
+// ---------------------------------------------------------------------------
+// ComplexNestedKey: @key uint32, @key nested struct, non-key double
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, ComplexNestedKey_KeySizeParity)
+{
+  check_key_size_parity(GET_TS(test_msgs, msg, ComplexNestedKey));
+}
+
+TEST(SerializerTest, ComplexNestedKey_KeySerialize)
+{
+  test_msgs::msg::ComplexNestedKey msg;
+  msg.uint32_key = 7;
+  msg.float64_value = 3.14;
+  check_key_serialize(GET_TS(test_msgs, msg, ComplexNestedKey), msg);
+}
+
+TEST(DeserializerTest, ComplexNestedKey_ExtractKey)
+{
+  test_msgs::msg::ComplexNestedKey msg;
+  msg.uint32_key = 7;
+  msg.float64_value = 3.14;
+  check_extractkey(GET_TS(test_msgs, msg, ComplexNestedKey), msg);
+}
+
+TEST(DeserializerTest, ComplexNestedKey_ExtractKeyBE)
+{
+  test_msgs::msg::ComplexNestedKey msg;
+  msg.uint32_key = 7;
+  msg.float64_value = 3.14;
+  check_extractkey_be(GET_TS(test_msgs, msg, ComplexNestedKey), msg);
+}

--- a/rmw_cyclonedds_cpp/test/test_rcl_interfaces.cpp
+++ b/rmw_cyclonedds_cpp/test/test_rcl_interfaces.cpp
@@ -1,0 +1,229 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_helpers.hpp"
+
+#include "rcl_interfaces/msg/parameter_type.hpp"
+#include "rcl_interfaces/msg/parameter_value.hpp"
+#include "rcl_interfaces/msg/parameter.hpp"
+#include "rcl_interfaces/msg/parameter_event.hpp"
+#include "rcl_interfaces/msg/parameter_descriptor.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+#include "rcl_interfaces/msg/detail/parameter_value__rosidl_typesupport_introspection_cpp.hpp"
+#include "rcl_interfaces/msg/detail/parameter__rosidl_typesupport_introspection_cpp.hpp"
+#include "rcl_interfaces/msg/detail/parameter_event__rosidl_typesupport_introspection_cpp.hpp"
+#include "rcl_interfaces/msg/detail/parameter_descriptor__rosidl_typesupport_introspection_cpp.hpp"
+#include "rcl_interfaces/msg/detail/set_parameters_result__rosidl_typesupport_introspection_cpp.hpp"
+
+extern "C" {
+#include "rcl_interfaces/msg/detail/parameter_value__rosidl_typesupport_introspection_c.h"
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — size bounds parity
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, RclParameterValue)
+{
+  check_parity(GET_TS(rcl_interfaces, msg, ParameterValue));
+}
+
+TEST(SizeTypeSupportTest, RclParameter)
+{
+  check_parity(GET_TS(rcl_interfaces, msg, Parameter));
+}
+
+TEST(SizeTypeSupportTest, RclParameterEvent)
+{
+  check_parity(GET_TS(rcl_interfaces, msg, ParameterEvent));
+}
+
+TEST(SizeTypeSupportTest, RclParameterDescriptor)
+{
+  check_parity(GET_TS(rcl_interfaces, msg, ParameterDescriptor));
+}
+
+TEST(SizeTypeSupportTest, RclSetParametersResult)
+{
+  check_parity(GET_TS(rcl_interfaces, msg, SetParametersResult));
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — concrete data size checks
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, RclParameterValueEmptyData)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterValueWithBoolArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  msg.bool_array_value = {true, false, true, true, false};
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterValueWithString)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  msg.string_value = "hello_parameter";
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterValueWithIntegerArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
+  msg.integer_array_value = {1, 2, 3, 4, 5};
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterValueWithStringArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  msg.string_array_value = {"foo", "bar", "baz"};
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterEventEmpty)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterEvent), &msg);
+}
+
+TEST(SizeTypeSupportTest, RclParameterEventPopulated)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  msg.node = "/my_node";
+  msg.stamp.sec = 100;
+  msg.stamp.nanosec = 0u;
+  rcl_interfaces::msg::Parameter p;
+  p.name = "my_param";
+  p.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  p.value.string_value = "value";
+  msg.new_parameters.push_back(p);
+  rcl_interfaces::msg::Parameter p2;
+  p2.name = "bool_array_param";
+  p2.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  p2.value.bool_array_value = {true, false, true};
+  msg.changed_parameters.push_back(p2);
+  check_parity_with_data(GET_TS(rcl_interfaces, msg, ParameterEvent), &msg);
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — C-type path
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, CType_ParameterValue)
+{
+  check_parity(GET_TS_C(rcl_interfaces, msg, ParameterValue));
+}
+
+// ---------------------------------------------------------------------------
+// SerializerTest
+// ---------------------------------------------------------------------------
+
+TEST(SerializerTest, RclParameterValueEmpty)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  check_serializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SerializerTest, RclParameterValueWithBoolArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  msg.bool_array_value = {true, false, true, true, false};
+  check_serializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SerializerTest, RclParameterValueWithStringArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  msg.string_array_value = {"alpha", "beta", "gamma"};
+  check_serializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), &msg);
+}
+
+TEST(SerializerTest, RclParameterEventEmpty)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  check_serializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterEvent), &msg);
+}
+
+TEST(SerializerTest, RclParameterEventPopulated)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  msg.node = "/some_node";
+  rcl_interfaces::msg::Parameter p;
+  p.name = "flag";
+  p.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  p.value.bool_array_value = {false, true};
+  msg.new_parameters.push_back(p);
+  check_serializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterEvent), &msg);
+}
+
+// ---------------------------------------------------------------------------
+// DeserializerTest
+// ---------------------------------------------------------------------------
+
+TEST(DeserializerTest, RclParameterValueEmpty)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  check_deserializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), msg);
+}
+
+TEST(DeserializerTest, RclParameterValueWithBoolArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  msg.bool_array_value = {true, false, true, true, false};
+  check_deserializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), msg);
+}
+
+TEST(DeserializerTest, RclParameterValueWithStringArray)
+{
+  rcl_interfaces::msg::ParameterValue msg;
+  msg.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  msg.string_array_value = {"alpha", "beta"};
+  check_deserializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterValue), msg);
+}
+
+TEST(DeserializerTest, RclParameterEventEmpty)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  check_deserializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterEvent), msg);
+}
+
+TEST(DeserializerTest, RclParameterEventPopulated)
+{
+  rcl_interfaces::msg::ParameterEvent msg;
+  msg.node = "/some_node";
+  rcl_interfaces::msg::Parameter p;
+  p.name = "my_flag";
+  p.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL_ARRAY;
+  p.value.bool_array_value = {false, true, false};
+  msg.new_parameters.push_back(p);
+  rcl_interfaces::msg::Parameter p2;
+  p2.name = "my_str";
+  p2.value.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  p2.value.string_value = "test";
+  msg.changed_parameters.push_back(p2);
+  check_deserializer_roundtrip(GET_TS(rcl_interfaces, msg, ParameterEvent), msg);
+}

--- a/rmw_cyclonedds_cpp/test/test_std_msgs.cpp
+++ b/rmw_cyclonedds_cpp/test/test_std_msgs.cpp
@@ -1,0 +1,558 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_helpers.hpp"
+
+// std_msgs
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "std_msgs/msg/header.hpp"
+#include "std_msgs/msg/float64_multi_array.hpp"
+#include "std_msgs/msg/detail/bool__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/int8__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/int32__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/int64__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/float64__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/string__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/header__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/int32_multi_array__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/float64_multi_array__rosidl_typesupport_introspection_cpp.hpp"
+#include "std_msgs/msg/detail/color_rgba__rosidl_typesupport_introspection_cpp.hpp"
+
+// visualization_msgs
+#include "visualization_msgs/msg/marker.hpp"
+#include "visualization_msgs/msg/marker_array.hpp"
+#include "visualization_msgs/msg/detail/marker__rosidl_typesupport_introspection_cpp.hpp"
+#include "visualization_msgs/msg/detail/marker_array__rosidl_typesupport_introspection_cpp.hpp"
+
+// C introspection type supports
+extern "C" {
+#include "std_msgs/msg/detail/bool__rosidl_typesupport_introspection_c.h"
+#include "std_msgs/msg/detail/int32__rosidl_typesupport_introspection_c.h"
+#include "std_msgs/msg/detail/string__rosidl_typesupport_introspection_c.h"
+#include "std_msgs/msg/detail/float64_multi_array__rosidl_typesupport_introspection_c.h"
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — fixed-size scalars
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, Bool)
+{
+  check_parity(GET_TS(std_msgs, msg, Bool));
+}
+
+TEST(SizeTypeSupportTest, Int8)
+{
+  check_parity(GET_TS(std_msgs, msg, Int8));
+}
+
+TEST(SizeTypeSupportTest, Int32)
+{
+  check_parity(GET_TS(std_msgs, msg, Int32));
+}
+
+TEST(SizeTypeSupportTest, Int64)
+{
+  check_parity(GET_TS(std_msgs, msg, Int64));
+}
+
+TEST(SizeTypeSupportTest, Float64)
+{
+  check_parity(GET_TS(std_msgs, msg, Float64));
+}
+
+TEST(SizeTypeSupportTest, ColorRgba)
+{
+  check_parity(GET_TS(std_msgs, msg, ColorRGBA));
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — variable-size / nested
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, String)
+{
+  check_parity(GET_TS(std_msgs, msg, String));
+}
+
+TEST(SizeTypeSupportTest, Header)
+{
+  check_parity(GET_TS(std_msgs, msg, Header));
+}
+
+TEST(SizeTypeSupportTest, Int32MultiArray)
+{
+  check_parity(GET_TS(std_msgs, msg, Int32MultiArray));
+}
+
+TEST(SizeTypeSupportTest, Float64MultiArray)
+{
+  check_parity(GET_TS(std_msgs, msg, Float64MultiArray));
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — Request variant
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, Int32AsRequest)
+{
+  check_parity(GET_TS(std_msgs, msg, Int32), SampleOrRequest::Request);
+}
+
+TEST(SizeTypeSupportTest, StringAsRequest)
+{
+  check_parity(GET_TS(std_msgs, msg, String), SampleOrRequest::Request);
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — visualization_msgs
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, Marker)
+{
+  check_parity(GET_TS(visualization_msgs, msg, Marker));
+}
+
+TEST(SizeTypeSupportTest, MarkerArray)
+{
+  check_parity(GET_TS(visualization_msgs, msg, MarkerArray));
+}
+
+TEST(SizeTypeSupportTest, MarkerArrayMinSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, MarkerArray));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 8u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), SIZE_MAX);
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — absolute size checks
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, BoolAbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(std_msgs, msg, Bool));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 5u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 5u);
+}
+
+TEST(SizeTypeSupportTest, Int32AbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(std_msgs, msg, Int32));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 8u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 8u);
+}
+
+TEST(SizeTypeSupportTest, Float64AbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(std_msgs, msg, Float64));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 12u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 12u);
+}
+
+TEST(SizeTypeSupportTest, StringMinSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(std_msgs, msg, String));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 9u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), SIZE_MAX);
+}
+
+TEST(SizeTypeSupportTest, Int32RequestAbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(std_msgs, msg, Int32));
+  CDRSizer sizer(members, SampleOrRequest::Request);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Request);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 24u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 24u);
+  EXPECT_EQ(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample));
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample));
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — concrete serialized-size checks
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, SerializedSizeBoolDefault)
+{
+  std_msgs::msg::Bool msg;
+  msg.data = false;
+  MessageMembersVariant members = make_message_members_variant(GET_TS(std_msgs, msg, Bool));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_serialized_size(&msg, SampleOrKey::Sample), 5u);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeInt32Values)
+{
+  std_msgs::msg::Int32 msg;
+  msg.data = 12345;
+  MessageMembersVariant members = make_message_members_variant(GET_TS(std_msgs, msg, Int32));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_serialized_size(&msg, SampleOrKey::Sample), 8u);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeStringEmpty)
+{
+  std_msgs::msg::String msg;
+  msg.data = "";
+  MessageMembersVariant members = make_message_members_variant(GET_TS(std_msgs, msg, String));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_serialized_size(&msg, SampleOrKey::Sample), 9u);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeStringHello)
+{
+  std_msgs::msg::String msg;
+  msg.data = "Hello";
+  MessageMembersVariant members = make_message_members_variant(GET_TS(std_msgs, msg, String));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_serialized_size(&msg, SampleOrKey::Sample), 14u);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeHeaderWithFrameId)
+{
+  std_msgs::msg::Header msg;
+  msg.frame_id = "map";
+  check_parity_with_data(GET_TS(std_msgs, msg, Header), &msg);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeFloat64MultiArrayPopulated)
+{
+  std_msgs::msg::Float64MultiArray msg;
+  msg.data.resize(5, 1.0);
+  msg.layout.dim.resize(1);
+  msg.layout.dim[0].label = "x";
+  msg.layout.dim[0].size = 5;
+  msg.layout.dim[0].stride = 5;
+  check_parity_with_data(GET_TS(std_msgs, msg, Float64MultiArray), &msg);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeMarkerDefault)
+{
+  visualization_msgs::msg::Marker msg;
+  check_parity_with_data(GET_TS(visualization_msgs, msg, Marker), &msg);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeMarkerWithPoints)
+{
+  visualization_msgs::msg::Marker msg;
+  msg.points.resize(50);
+  msg.colors.resize(50);
+  msg.header.frame_id = "world";
+  msg.text = "label";
+  check_parity_with_data(GET_TS(visualization_msgs, msg, Marker), &msg);
+}
+
+TEST(SizeTypeSupportTest, SerializedSizeMarkerArrayPopulated)
+{
+  visualization_msgs::msg::MarkerArray msg;
+  msg.markers.resize(5);
+  for (auto & m : msg.markers) {
+    m.points.resize(10);
+    m.header.frame_id = "map";
+  }
+  check_parity_with_data(GET_TS(visualization_msgs, msg, MarkerArray), &msg);
+}
+
+TEST(SizeTypeSupportTest, MarkerMemberCacheKinds)
+{
+  // Build the Marker type tree and verify that the SzMemberCache fast-path
+  // tags are actually populated — i.e. the optimization is doing something.
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS(visualization_msgs, msg, Marker));
+  auto [root, storage] = make_sz_struct(members);
+
+  // Count how many members fall into each kind.
+  size_t n_fixed = 0, n_string = 0, n_struct = 0;
+  size_t n_cseq = 0, n_cppvec = 0, n_slow = 0, n_other = 0;
+  for (const auto & m : storage.all_members) {
+    switch (m.cache.kind) {
+      case SzMemberKind::Fixed:      ++n_fixed; break;
+      case SzMemberKind::String:     ++n_string; break;
+      case SzMemberKind::Struct:     ++n_struct; break;
+      case SzMemberKind::CSeqFixed:  ++n_cseq; break;
+      case SzMemberKind::CppVecFixed: ++n_cppvec; break;
+      case SzMemberKind::Slow:       ++n_slow; break;
+      default:                       ++n_other; break;
+    }
+  }
+
+  // Marker has primitives (int32, float64, …) → Fixed
+  EXPECT_GT(n_fixed, 0u) << "expected Fixed members (primitives, stamp, etc.)";
+  // Marker has std::string fields (ns, frame_id, text, mesh_resource) → String
+  EXPECT_GT(n_string, 0u) << "expected String members";
+  // Marker has std::vector<Point>, std::vector<ColorRGBA> → CppVecFixed
+  EXPECT_GT(n_cppvec, 0u) << "expected CppVecFixed members (points, colors)";
+  // Marker has nested Header, Pose, etc. that are NOT fixed → Struct
+  EXPECT_GT(n_struct, 0u) << "expected Struct members (Header with frame_id)";
+  // The vast majority of members should use a fast path, not Slow.
+  size_t total = n_fixed + n_string + n_struct + n_cseq + n_cppvec + n_slow + n_other;
+  EXPECT_LT(n_slow, total / 2) << "most members should use a fast path, not Slow";
+
+  // Verify the actual size computation still matches the old impl.
+  visualization_msgs::msg::Marker msg;
+  msg.header.frame_id = "test";
+  msg.ns = "ns";
+  msg.text = "hello";
+  msg.points.resize(10);
+  msg.colors.resize(10);
+  check_parity_with_data(GET_TS(visualization_msgs, msg, Marker), &msg);
+}
+
+// ---------------------------------------------------------------------------
+// SizeTypeSupportTest — C-type path
+// ---------------------------------------------------------------------------
+
+TEST(SizeTypeSupportTest, CType_Bool)
+{
+  check_parity(GET_TS_C(std_msgs, msg, Bool));
+}
+
+TEST(SizeTypeSupportTest, CType_Int32)
+{
+  check_parity(GET_TS_C(std_msgs, msg, Int32));
+}
+
+TEST(SizeTypeSupportTest, CType_String)
+{
+  check_parity(GET_TS_C(std_msgs, msg, String));
+}
+
+TEST(SizeTypeSupportTest, CType_Float64MultiArray)
+{
+  check_parity(GET_TS_C(std_msgs, msg, Float64MultiArray));
+}
+
+TEST(SizeTypeSupportTest, CType_BoolAbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS_C(std_msgs, msg, Bool));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 5u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 5u);
+}
+
+TEST(SizeTypeSupportTest, CType_Int32AbsoluteSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS_C(std_msgs, msg, Int32));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_EQ(sizer.get_min_serialized_size(SampleOrKey::Sample), 8u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), 8u);
+}
+
+TEST(SizeTypeSupportTest, CType_StringMinSize)
+{
+  MessageMembersVariant members =
+    make_message_members_variant(GET_TS_C(std_msgs, msg, String));
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  EXPECT_GT(sizer.get_min_serialized_size(SampleOrKey::Sample), 0u);
+  EXPECT_EQ(sizer.get_max_serialized_size(SampleOrKey::Sample), SIZE_MAX);
+}
+
+// ---------------------------------------------------------------------------
+// SerializerTest — std_msgs + visualization_msgs
+// ---------------------------------------------------------------------------
+
+TEST(SerializerTest, Bool)
+{
+  std_msgs::msg::Bool msg;
+  msg.data = true;
+  check_serializer_roundtrip(GET_TS(std_msgs, msg, Bool), &msg);
+}
+
+TEST(SerializerTest, Int32)
+{
+  std_msgs::msg::Int32 msg;
+  msg.data = -42;
+  check_serializer_roundtrip(GET_TS(std_msgs, msg, Int32), &msg);
+}
+
+TEST(SerializerTest, String)
+{
+  std_msgs::msg::String msg;
+  msg.data = "hello world";
+  check_serializer_roundtrip(GET_TS(std_msgs, msg, String), &msg);
+}
+
+TEST(SerializerTest, Header)
+{
+  std_msgs::msg::Header msg;
+  msg.frame_id = "base_link";
+  msg.stamp.sec = 123;
+  msg.stamp.nanosec = 456789u;
+  check_serializer_roundtrip(GET_TS(std_msgs, msg, Header), &msg);
+}
+
+TEST(SerializerTest, Float64MultiArrayPopulated)
+{
+  std_msgs::msg::Float64MultiArray msg;
+  msg.data.resize(10);
+  for (size_t i = 0; i < msg.data.size(); ++i) {
+    msg.data[i] = static_cast<double>(i) * 1.5;
+  }
+  msg.layout.dim.resize(1);
+  msg.layout.dim[0].label = "x";
+  msg.layout.dim[0].size = 10;
+  msg.layout.dim[0].stride = 10;
+  check_serializer_roundtrip(GET_TS(std_msgs, msg, Float64MultiArray), &msg);
+}
+
+TEST(SerializerTest, MarkerDefault)
+{
+  visualization_msgs::msg::Marker msg;
+  check_serializer_roundtrip(GET_TS(visualization_msgs, msg, Marker), &msg);
+}
+
+TEST(SerializerTest, MarkerPopulated)
+{
+  visualization_msgs::msg::Marker msg;
+  msg.header.frame_id = "map";
+  msg.ns = "test_ns";
+  msg.id = 7;
+  msg.type = visualization_msgs::msg::Marker::POINTS;
+  msg.action = visualization_msgs::msg::Marker::ADD;
+  msg.text = "some label";
+  msg.mesh_resource = "package://pkg/mesh.dae";
+  msg.points.resize(100);
+  for (auto & p : msg.points) {
+    p.x = 1.0; p.y = 2.0; p.z = 3.0;
+  }
+  msg.colors.resize(100);
+  for (auto & c : msg.colors) {
+    c.r = 1.0f; c.g = 0.5f; c.b = 0.0f; c.a = 1.0f;
+  }
+  check_serializer_roundtrip(GET_TS(visualization_msgs, msg, Marker), &msg);
+}
+
+TEST(SerializerTest, MarkerArrayPopulated)
+{
+  visualization_msgs::msg::MarkerArray msg;
+  msg.markers.resize(3);
+  for (size_t i = 0; i < msg.markers.size(); ++i) {
+    msg.markers[i].header.frame_id = "map";
+    msg.markers[i].ns = "ns";
+    msg.markers[i].id = static_cast<int32_t>(i);
+    msg.markers[i].text = "label";
+    msg.markers[i].points.resize(50);
+    msg.markers[i].colors.resize(50);
+  }
+  check_serializer_roundtrip(GET_TS(visualization_msgs, msg, MarkerArray), &msg);
+}
+
+// ---------------------------------------------------------------------------
+// DeserializerTest — std_msgs + visualization_msgs
+// ---------------------------------------------------------------------------
+
+TEST(DeserializerTest, Bool)
+{
+  std_msgs::msg::Bool msg;
+  msg.data = true;
+  check_deserializer_roundtrip(GET_TS(std_msgs, msg, Bool), msg);
+}
+
+TEST(DeserializerTest, Int32)
+{
+  std_msgs::msg::Int32 msg;
+  msg.data = -42;
+  check_deserializer_roundtrip(GET_TS(std_msgs, msg, Int32), msg);
+}
+
+TEST(DeserializerTest, String)
+{
+  std_msgs::msg::String msg;
+  msg.data = "hello world";
+  check_deserializer_roundtrip(GET_TS(std_msgs, msg, String), msg);
+}
+
+TEST(DeserializerTest, Header)
+{
+  std_msgs::msg::Header msg;
+  msg.frame_id = "base_link";
+  msg.stamp.sec = 123;
+  msg.stamp.nanosec = 456789u;
+  check_deserializer_roundtrip(GET_TS(std_msgs, msg, Header), msg);
+}
+
+TEST(DeserializerTest, Float64MultiArrayPopulated)
+{
+  std_msgs::msg::Float64MultiArray msg;
+  msg.data.resize(10);
+  for (size_t i = 0; i < msg.data.size(); ++i) {
+    msg.data[i] = static_cast<double>(i) * 1.5;
+  }
+  msg.layout.dim.resize(1);
+  msg.layout.dim[0].label = "x";
+  msg.layout.dim[0].size = 10;
+  msg.layout.dim[0].stride = 10;
+  check_deserializer_roundtrip(GET_TS(std_msgs, msg, Float64MultiArray), msg);
+}
+
+TEST(DeserializerTest, MarkerDefault)
+{
+  visualization_msgs::msg::Marker msg;
+  check_deserializer_roundtrip(GET_TS(visualization_msgs, msg, Marker), msg);
+}
+
+TEST(DeserializerTest, MarkerPopulated)
+{
+  visualization_msgs::msg::Marker msg;
+  msg.header.frame_id = "map";
+  msg.ns = "test_ns";
+  msg.id = 7;
+  msg.type = visualization_msgs::msg::Marker::POINTS;
+  msg.action = visualization_msgs::msg::Marker::ADD;
+  msg.text = "some label";
+  msg.mesh_resource = "package://pkg/mesh.dae";
+  msg.points.resize(100);
+  for (auto & p : msg.points) {
+    p.x = 1.0; p.y = 2.0; p.z = 3.0;
+  }
+  msg.colors.resize(100);
+  for (auto & c : msg.colors) {
+    c.r = 1.0f; c.g = 0.5f; c.b = 0.0f; c.a = 1.0f;
+  }
+  check_deserializer_roundtrip(GET_TS(visualization_msgs, msg, Marker), msg);
+}
+
+TEST(DeserializerTest, MarkerArrayPopulated)
+{
+  visualization_msgs::msg::MarkerArray msg;
+  msg.markers.resize(3);
+  for (size_t i = 0; i < msg.markers.size(); ++i) {
+    msg.markers[i].header.frame_id = "map";
+    msg.markers[i].ns = "ns";
+    msg.markers[i].id = static_cast<int32_t>(i);
+    msg.markers[i].text = "label";
+    msg.markers[i].points.resize(50);
+    msg.markers[i].colors.resize(50);
+  }
+  check_deserializer_roundtrip(GET_TS(visualization_msgs, msg, MarkerArray), msg);
+}

--- a/rmw_cyclonedds_cpp/test/test_test_msgs.cpp
+++ b/rmw_cyclonedds_cpp/test/test_test_msgs.cpp
@@ -1,0 +1,405 @@
+// Test new CDR implementation against old for test_msgs types used by
+// test_communication (BasicTypes, Arrays, BoundedSequences, etc.)
+
+#include "test_helpers.hpp"
+
+// C++ message types
+#include "test_msgs/msg/basic_types.hpp"
+#include "test_msgs/msg/arrays.hpp"
+#include "test_msgs/msg/bounded_sequences.hpp"
+#include "test_msgs/msg/unbounded_sequences.hpp"
+#include "test_msgs/msg/defaults.hpp"
+#include "test_msgs/msg/constants.hpp"
+#include "test_msgs/msg/strings.hpp"
+#include "test_msgs/msg/multi_nested.hpp"
+
+// rmw_dds_common message types (used during DDS discovery)
+#include "rmw_dds_common/msg/participant_entities_info.hpp"
+#include "rmw_dds_common/msg/node_entities_info.hpp"
+#include "rmw_dds_common/msg/gid.hpp"
+
+// C++ introspection
+#include "test_msgs/msg/detail/basic_types__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/arrays__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/bounded_sequences__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/unbounded_sequences__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/defaults__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/constants__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/strings__rosidl_typesupport_introspection_cpp.hpp"
+#include "test_msgs/msg/detail/multi_nested__rosidl_typesupport_introspection_cpp.hpp"
+#include "rmw_dds_common/msg/detail/participant_entities_info__rosidl_typesupport_introspection_cpp.hpp"
+#include "rmw_dds_common/msg/detail/node_entities_info__rosidl_typesupport_introspection_cpp.hpp"
+#include "rmw_dds_common/msg/detail/gid__rosidl_typesupport_introspection_cpp.hpp"
+
+// C introspection
+extern "C" {
+#include "test_msgs/msg/detail/basic_types__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/arrays__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/bounded_sequences__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/unbounded_sequences__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/defaults__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/constants__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/strings__rosidl_typesupport_introspection_c.h"
+#include "test_msgs/msg/detail/multi_nested__rosidl_typesupport_introspection_c.h"
+}
+
+// C introspection for rmw_dds_common
+extern "C" {
+#include "rmw_dds_common/msg/detail/participant_entities_info__rosidl_typesupport_introspection_c.h"
+#include "rmw_dds_common/msg/detail/node_entities_info__rosidl_typesupport_introspection_c.h"
+#include "rmw_dds_common/msg/detail/gid__rosidl_typesupport_introspection_c.h"
+}
+
+// C message types and init/fini
+#include "test_msgs/msg/detail/basic_types__functions.h"
+#include "test_msgs/msg/detail/arrays__functions.h"
+#include "test_msgs/msg/detail/bounded_sequences__functions.h"
+#include "test_msgs/msg/detail/unbounded_sequences__functions.h"
+#include "test_msgs/msg/detail/defaults__functions.h"
+#include "test_msgs/msg/detail/constants__functions.h"
+#include "test_msgs/msg/detail/strings__functions.h"
+#include "test_msgs/msg/detail/multi_nested__functions.h"
+#include "rmw_dds_common/msg/detail/participant_entities_info__functions.h"
+
+// ===========================================================================
+// Size parity: CDRSizer min/max matches CDRWriter (C++ introspection)
+// ===========================================================================
+
+TEST(SizeParityCpp, BasicTypes)    { check_parity(GET_TS(test_msgs, msg, BasicTypes)); }
+// CDRSizer computes a tighter min bound than CDRWriter for types with
+// arrays of alignment-variant structs; only check min ≤ writer_min and max ==.
+TEST(SizeParityCpp, Arrays)
+{
+  auto ts = GET_TS(test_msgs, msg, Arrays);
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+  EXPECT_LE(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample));
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample));
+}
+TEST(SizeParityCpp, BoundedSeqs)   { check_parity(GET_TS(test_msgs, msg, BoundedSequences)); }
+TEST(SizeParityCpp, UnboundedSeqs) { check_parity(GET_TS(test_msgs, msg, UnboundedSequences)); }
+TEST(SizeParityCpp, Defaults)      { check_parity(GET_TS(test_msgs, msg, Defaults)); }
+TEST(SizeParityCpp, Constants)     { check_parity(GET_TS(test_msgs, msg, Constants)); }
+TEST(SizeParityCpp, Strings)       { check_parity(GET_TS(test_msgs, msg, Strings)); }
+TEST(SizeParityCpp, MultiNested)
+{
+  auto ts = GET_TS(test_msgs, msg, MultiNested);
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+  EXPECT_LE(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample));
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample));
+}
+
+// ===========================================================================
+// Size parity: CDRSizer min/max matches CDRWriter (C introspection)
+// ===========================================================================
+
+TEST(SizeParityC, BasicTypes)    { check_parity(GET_TS_C(test_msgs, msg, BasicTypes)); }
+TEST(SizeParityC, Arrays)
+{
+  auto ts = GET_TS_C(test_msgs, msg, Arrays);
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+  EXPECT_LE(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample));
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample));
+}
+TEST(SizeParityC, BoundedSeqs)   { check_parity(GET_TS_C(test_msgs, msg, BoundedSequences)); }
+TEST(SizeParityC, UnboundedSeqs) { check_parity(GET_TS_C(test_msgs, msg, UnboundedSequences)); }
+TEST(SizeParityC, Defaults)      { check_parity(GET_TS_C(test_msgs, msg, Defaults)); }
+TEST(SizeParityC, Constants)     { check_parity(GET_TS_C(test_msgs, msg, Constants)); }
+TEST(SizeParityC, Strings)       { check_parity(GET_TS_C(test_msgs, msg, Strings)); }
+TEST(SizeParityC, MultiNested)
+{
+  auto ts = GET_TS_C(test_msgs, msg, MultiNested);
+  MessageMembersVariant members = make_message_members_variant(ts);
+  CDRSizer sizer(members, SampleOrRequest::Sample);
+  auto writer = make_cdr_writer(members, SampleOrRequest::Sample);
+  EXPECT_LE(
+    sizer.get_min_serialized_size(SampleOrKey::Sample),
+    writer->get_min_serialized_size(SampleOrKey::Sample));
+  EXPECT_EQ(
+    sizer.get_max_serialized_size(SampleOrKey::Sample),
+    writer->get_max_serialized_size(SampleOrKey::Sample));
+}
+
+// ===========================================================================
+// Serialize parity + roundtrip with data (C++)
+// ===========================================================================
+
+TEST(SerializerCpp, BasicTypesDefault)
+{
+  test_msgs::msg::BasicTypes msg{};
+  auto ts = GET_TS(test_msgs, msg, BasicTypes);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, BasicTypesPopulated)
+{
+  test_msgs::msg::BasicTypes msg{};
+  msg.bool_value = true;
+  msg.byte_value = 255;
+  msg.char_value = 'k';
+  msg.float32_value = 1.0f;
+  msg.float64_value = 2.0;
+  msg.int8_value = 3;
+  msg.uint8_value = 4;
+  msg.int16_value = 5;
+  msg.uint16_value = 6;
+  msg.int32_value = 7;
+  msg.uint32_value = 8;
+  msg.int64_value = 9;
+  msg.uint64_value = 10;
+  auto ts = GET_TS(test_msgs, msg, BasicTypes);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, ArraysDefault)
+{
+  test_msgs::msg::Arrays msg{};
+  auto ts = GET_TS(test_msgs, msg, Arrays);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, BoundedSequencesDefault)
+{
+  test_msgs::msg::BoundedSequences msg{};
+  auto ts = GET_TS(test_msgs, msg, BoundedSequences);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, BoundedSequencesPopulated)
+{
+  test_msgs::msg::BoundedSequences msg{};
+  test_msgs::msg::BasicTypes bt{};
+  bt.bool_value = true;
+  bt.byte_value = 255;
+  bt.char_value = 'k';
+  bt.float32_value = 1.0f;
+  bt.float64_value = 2.0;
+  bt.int8_value = 3;
+  bt.uint8_value = 4;
+  bt.int16_value = 5;
+  bt.uint16_value = 6;
+  bt.int32_value = 7;
+  bt.uint32_value = 8;
+  bt.int64_value = 9;
+  bt.uint64_value = 10;
+  msg.basic_types_values.push_back(bt);
+  auto ts = GET_TS(test_msgs, msg, BoundedSequences);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, UnboundedSequencesDefault)
+{
+  test_msgs::msg::UnboundedSequences msg{};
+  auto ts = GET_TS(test_msgs, msg, UnboundedSequences);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, DefaultsDefault)
+{
+  test_msgs::msg::Defaults msg{};
+  auto ts = GET_TS(test_msgs, msg, Defaults);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, StringsDefault)
+{
+  test_msgs::msg::Strings msg{};
+  auto ts = GET_TS(test_msgs, msg, Strings);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, StringsPopulated)
+{
+  test_msgs::msg::Strings msg{};
+  msg.string_value = "hello world";
+  msg.bounded_string_value = "bounded";
+  auto ts = GET_TS(test_msgs, msg, Strings);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, MultiNestedDefault)
+{
+  test_msgs::msg::MultiNested msg{};
+  auto ts = GET_TS(test_msgs, msg, MultiNested);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+// ===========================================================================
+// rmw_dds_common discovery messages (C++)
+// ===========================================================================
+
+// CDRWriter overreports char CDR size (2 vs 1), so skip size parity for Gid.
+TEST(SerializerCpp, GidDefault)
+{
+  rmw_dds_common::msg::Gid msg{};
+  auto ts = GET_TS(rmw_dds_common, msg, Gid);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, NodeEntitiesInfoDefault)
+{
+  rmw_dds_common::msg::NodeEntitiesInfo msg{};
+  auto ts = GET_TS(rmw_dds_common, msg, NodeEntitiesInfo);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, NodeEntitiesInfoPopulated)
+{
+  rmw_dds_common::msg::NodeEntitiesInfo msg{};
+  msg.node_namespace = "/test";
+  msg.node_name = "my_node";
+  rmw_dds_common::msg::Gid gid{};
+  gid.data[0] = 1;
+  msg.reader_gid_seq.push_back(gid);
+  msg.writer_gid_seq.push_back(gid);
+  auto ts = GET_TS(rmw_dds_common, msg, NodeEntitiesInfo);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, ParticipantEntitiesInfoDefault)
+{
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg{};
+  auto ts = GET_TS(rmw_dds_common, msg, ParticipantEntitiesInfo);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+TEST(SerializerCpp, ParticipantEntitiesInfoPopulated)
+{
+  rmw_dds_common::msg::ParticipantEntitiesInfo msg{};
+  msg.gid.data[0] = 42;
+  rmw_dds_common::msg::NodeEntitiesInfo nei{};
+  nei.node_namespace = "/ns";
+  nei.node_name = "node1";
+  msg.node_entities_info_seq.push_back(nei);
+  auto ts = GET_TS(rmw_dds_common, msg, ParticipantEntitiesInfo);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  check_deserializer_roundtrip(ts, msg);
+}
+
+// ===========================================================================
+// Serialize parity with C introspection + C data
+// ===========================================================================
+
+TEST(SerializerC, BasicTypesDefault)
+{
+  test_msgs__msg__BasicTypes msg;
+  test_msgs__msg__BasicTypes__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, BasicTypes);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__BasicTypes__fini(&msg);
+}
+
+TEST(SerializerC, ArraysDefault)
+{
+  test_msgs__msg__Arrays msg;
+  test_msgs__msg__Arrays__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, Arrays);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__Arrays__fini(&msg);
+}
+
+TEST(SerializerC, BoundedSequencesDefault)
+{
+  test_msgs__msg__BoundedSequences msg;
+  test_msgs__msg__BoundedSequences__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, BoundedSequences);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__BoundedSequences__fini(&msg);
+}
+
+TEST(SerializerC, UnboundedSequencesDefault)
+{
+  test_msgs__msg__UnboundedSequences msg;
+  test_msgs__msg__UnboundedSequences__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, UnboundedSequences);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__UnboundedSequences__fini(&msg);
+}
+
+TEST(SerializerC, DefaultsDefault)
+{
+  test_msgs__msg__Defaults msg;
+  test_msgs__msg__Defaults__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, Defaults);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__Defaults__fini(&msg);
+}
+
+TEST(SerializerC, StringsDefault)
+{
+  test_msgs__msg__Strings msg;
+  test_msgs__msg__Strings__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, Strings);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__Strings__fini(&msg);
+}
+
+TEST(SerializerC, MultiNestedDefault)
+{
+  test_msgs__msg__MultiNested msg;
+  test_msgs__msg__MultiNested__init(&msg);
+  auto ts = GET_TS_C(test_msgs, msg, MultiNested);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  test_msgs__msg__MultiNested__fini(&msg);
+}
+
+TEST(SerializerC, ParticipantEntitiesInfoDefault)
+{
+  rmw_dds_common__msg__ParticipantEntitiesInfo msg;
+  rmw_dds_common__msg__ParticipantEntitiesInfo__init(&msg);
+  auto ts = GET_TS_C(rmw_dds_common, msg, ParticipantEntitiesInfo);
+  check_parity_with_data(ts, &msg);
+  check_serializer_roundtrip(ts, &msg);
+  rmw_dds_common__msg__ParticipantEntitiesInfo__fini(&msg);
+}

--- a/rmw_cyclonedds_cpp/test/test_wstring.cpp
+++ b/rmw_cyclonedds_cpp/test/test_wstring.cpp
@@ -1,0 +1,51 @@
+// Copyright 2019 Rover Robotics via Dan Rose
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "test_helpers.hpp"
+
+#include "example_interfaces/msg/w_string.hpp"
+#include "example_interfaces/msg/detail/w_string__rosidl_typesupport_introspection_cpp.hpp"
+
+TEST(SizeTypeSupportTest, WString)
+{
+  check_parity(GET_TS(example_interfaces, msg, WString));
+}
+
+TEST(SerializerTest, WStringEmpty)
+{
+  example_interfaces::msg::WString msg;
+  msg.data = u"";
+  check_serializer_roundtrip(GET_TS(example_interfaces, msg, WString), &msg);
+}
+
+TEST(SerializerTest, WStringPopulated)
+{
+  example_interfaces::msg::WString msg;
+  msg.data = u"Hello \u4e16\u754c";  // "Hello 世界"
+  check_serializer_roundtrip(GET_TS(example_interfaces, msg, WString), &msg);
+}
+
+TEST(DeserializerTest, WStringEmpty)
+{
+  example_interfaces::msg::WString msg;
+  msg.data = u"";
+  check_deserializer_roundtrip(GET_TS(example_interfaces, msg, WString), msg);
+}
+
+TEST(DeserializerTest, WStringPopulated)
+{
+  example_interfaces::msg::WString msg;
+  msg.data = u"Hello \u4e16\u754c";  // "Hello 世界"
+  check_deserializer_roundtrip(GET_TS(example_interfaces, msg, WString), msg);
+}


### PR DESCRIPTION
## Description

This is a vibe coded rewrite of the serialization, de serialization and size computation code. 

This implementation is depending on the msg 2-3x faster in serialization and de serialization,
and about 10x faster in size computation. Note that the size computation must be done before
serialization, and was taking ~50% of the cpu time in the old implementation during publish.

The bottom line here is there more nested and complex the msg the faster the new implementation.
For 'bulk types' like images there is almost no difference.

With the performance roundtrip benchmarks, using marker arrays, I can see a CPU time reduction
from ~60% to ~16%. The time it takes to call publish and CPU time usage is now close to the one of
fastRTPS.

```
---------------------------------------------------------------------------------
Benchmark                                       Time             CPU   Iterations
---------------------------------------------------------------------------------
BM_OldImpl_SizeBound/Bool                    1.78 ns         1.78 ns    336018102
BM_NewImpl_SizeBound/Bool                    1.42 ns         1.42 ns    489091256
BM_OldImpl_SizeBound/Int32                   1.78 ns         1.78 ns    392841783
BM_NewImpl_SizeBound/Int32                   1.42 ns         1.42 ns    485654865
BM_OldImpl_SizeBound/String                  1.79 ns         1.79 ns    392450706
BM_NewImpl_SizeBound/String                  1.43 ns         1.43 ns    491473704
BM_OldImpl_SizeBound/Header                  1.79 ns         1.79 ns    391639186
BM_NewImpl_SizeBound/Header                  1.42 ns         1.42 ns    467252090
BM_OldImpl_SizeBound/Float64MultiArray       1.97 ns         1.96 ns    356346563
BM_NewImpl_SizeBound/Float64MultiArray       1.43 ns         1.43 ns    490866785
BM_OldImpl_SizeBound/Marker                  1.79 ns         1.79 ns    392071872
BM_NewImpl_SizeBound/Marker                  1.43 ns         1.43 ns    491146113
BM_OldImpl_SizeBound/MarkerArray             1.97 ns         1.97 ns    356228339
BM_NewImpl_SizeBound/MarkerArray             1.43 ns         1.43 ns    491258794
BM_OldImpl_SizeBound/PointCloud2             1.97 ns         1.97 ns    356165057
BM_NewImpl_SizeBound/PointCloud2             1.43 ns         1.43 ns    490669743
BM_OldImpl_SizeBound/LaserScan               1.79 ns         1.79 ns    391888883
BM_NewImpl_SizeBound/LaserScan               1.43 ns         1.43 ns    486648872
BM_OldImpl_SizeBound/Image                   1.79 ns         1.79 ns    392130868
BM_NewImpl_SizeBound/Image                   1.42 ns         1.42 ns    479932678
BM_OldImpl_SerializedSize                    9650 ns         9650 ns        70004
BM_NewImpl_SerializedSize                     716 ns          716 ns       979024
BM_OldImpl_SerializedSizeEstimate            9767 ns         9766 ns        70222
BM_NewImpl_SerializedSizeEstimate             757 ns          757 ns       891830
BM_OldImpl_Serialize                        12769 ns        12768 ns        56815
BM_NewImpl_Serialize                         5194 ns         5194 ns       134505
BM_NewImpl_Deserialize                       5259 ns         5259 ns       134461
BM_OldImpl_Deserialize                      12643 ns        12643 ns        54640
BM_Marker_Serialize_Old                       539 ns          539 ns      1320461
BM_Marker_Serialize                           205 ns          205 ns      3423652
BM_Marker_Deserialize_Old                     562 ns          562 ns      1279175
BM_Marker_Deserialize                         199 ns          199 ns      3507109
BM_TFMessage_Dynamic_Serialize_Old            167 ns          167 ns      4327852
BM_TFMessage_Dynamic_Serialize               63.8 ns         63.8 ns     11137447
BM_TFMessage_Dynamic_Deserialize_Old          165 ns          165 ns      4240901
BM_TFMessage_Dynamic_Deserialize             63.9 ns         63.9 ns     10920823
BM_TFMessage_Static_Serialize_Old            2443 ns         2442 ns       290161
BM_TFMessage_Static_Serialize                1033 ns         1033 ns       678791
BM_TFMessage_Static_Deserialize_Old          2434 ns         2434 ns       268255
BM_TFMessage_Static_Deserialize               993 ns          993 ns       707200
BM_PointCloud2_SerializedSize_Old             438 ns          438 ns      1612023
BM_PointCloud2_SerializedSize                43.9 ns         43.9 ns     16023671
BM_PointCloud2_Serialize_Old               447257 ns       447221 ns         1572 bytes_per_second=20.4718Gi/s
BM_PointCloud2_Serialize                   454261 ns       454244 ns         1538 bytes_per_second=20.1553Gi/s
BM_PointCloud2_Deserialize_Old             437504 ns       437466 ns         1602 bytes_per_second=20.9283Gi/s
BM_PointCloud2_Deserialize                 436420 ns       436368 ns         1607 bytes_per_second=20.9809Gi/s
BM_LaserScan_SerializedSize_Old               147 ns          147 ns      4866572
BM_LaserScan_SerializedSize                  12.8 ns         12.8 ns     55122595
BM_LaserScan_Serialize_Old                    221 ns          221 ns      3072972 bytes_per_second=36.6873Gi/s
BM_LaserScan_Serialize                       94.7 ns         94.7 ns      7369829 bytes_per_second=85.5507Gi/s
BM_LaserScan_Deserialize_Old                  228 ns          228 ns      3195329 bytes_per_second=35.5899Gi/s
BM_LaserScan_Deserialize                     93.3 ns         93.3 ns      7508956 bytes_per_second=86.8809Gi/s
BM_Image_SerializedSize_Old                   135 ns          135 ns      5128440
BM_Image_SerializedSize                      10.3 ns         10.3 ns     67626332
BM_Image_Serialize_Old                     116602 ns       116586 ns         6012 bytes_per_second=22.0864Gi/s
BM_Image_Serialize                         116059 ns       116050 ns         6016 bytes_per_second=22.1884Gi/s
BM_Image_Deserialize_Old                   115698 ns       115693 ns         5991 bytes_per_second=22.257Gi/s
BM_Image_Deserialize                       115590 ns       115584 ns         6031 bytes_per_second=22.2779Gi/s
``` 

Fixes # (issue)

Performance regressions introduced with the key support patches.

### Is this user-facing behavior change?

No

### Did you use Generative AI?

Yes, this is completely vibe coded.

### Additional Information

All tests in test_communication are passing.

As to why this is actually faster:
- The recent changes for the key support combined the type support for serialization and de serialization, making
the types that must be loaded while traversing the data bigger. I was suspecting cache line issues, as some experiments showed, that the speed was sensitive to the size of the types of type system.
- Therefore I went with a 'Array of Structures (AoS) and Structure of Arrays (SoA)' approach and told the AI to split the code in this way.

Note, there are still 2 places in the rmw_node implementation were the old type system is used.

I must say I am a bit torn about this. I don't fully trust AI written code, and I must admit this is a code bomb drop.
On the other hand the benchmark result speak for themself.

I wonder how we should go forward with this ? 
- Merge as is ?
- Merge, but as a new cyclone flavor ? "rmw_cyclonedds_cpp_ai_slop_fast"

@eboasson @mjcarroll Opinions ?