### PR TITLE
Fix KEEP_ALL history handling in subscription callback

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -570,9 +570,9 @@ extern "C" rmw_ret_t rmw_subscription_set_on_new_message_callback(
     // For KEEP_ALL history, depth is reported as 0 (since CycloneDDS internally
     // uses -1 for unlimited depth, which gets mapped to 0 in dds_qos_to_rmw_qos).
     // In that case, pass through the full unread_count instead of clipping to 0.
-    size_t events = (sub_qos.depth > 0)
-      ? std::min(data->unread_count, sub_qos.depth)
-      : data->unread_count;
+    size_t events = (sub_qos.depth > 0) ?
+      std::min(data->unread_count, sub_qos.depth) :
+      data->unread_count;
 
     callback(user_data, events);
     data->unread_count = 0;

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -567,7 +567,12 @@ extern "C" rmw_ret_t rmw_subscription_set_on_new_message_callback(
       return RMW_RET_ERROR;
     }
 
-    size_t events = std::min(data->unread_count, sub_qos.depth);
+    // For KEEP_ALL history, depth is reported as 0 (since CycloneDDS internally
+    // uses -1 for unlimited depth, which gets mapped to 0 in dds_qos_to_rmw_qos).
+    // In that case, pass through the full unread_count instead of clipping to 0.
+    size_t events = (sub_qos.depth > 0)
+      ? std::min(data->unread_count, sub_qos.depth)
+      : data->unread_count;
 
     callback(user_data, events);
     data->unread_count = 0;


### PR DESCRIPTION
## Description

Fix `rmw_subscription_set_on_new_message_callback` incorrectly clipping `unread_count` to 0 for KEEP_ALL history subscriptions, causing `EventsExecutor` to never deliver transient-local cached messages.

When a subscription uses KEEP_ALL history, CycloneDDS internally represents unlimited depth as -1, which gets mapped to `depth=0` in `dds_qos_to_rmw_qos`. The existing code unconditionally calls `std::min(unread_count, depth)`, which evaluates to `std::min(N, 0) == 0` — the callback fires with 0 events and the executor never processes the cached messages.

This manifests as transient-local topics (e.g. `/tf_static`) with KEEP_ALL durability not being received by any subscriber driven by `EventsExecutor`.
The fix guards the `std::min` with a `depth > 0` check, passing through the full `unread_count` for KEEP_ALL.

Regression test in rclcpp: https://github.com/ros2/rclcpp/pull/3152

### Is this user-facing behavior change?

Yes. Transient-local topics with KEEP_ALL QoS (notably `/tf_static`) are now correctly received when using `EventsExecutor` with `rmw_cyclonedds_cpp`. Previously these messages were silently dropped.

### Did you use Generative AI?

Yes — GitHub Copilot (Claude Opus 4.6) was used to assist with root-cause analysis, implementing the fix.

### Additional Information

- Only `rmw_subscription_set_on_new_message_callback` is affected; `rmw_service_set_on_new_request_callback` and `rmw_client_set_on_new_response_callback` already pass `unread_count` directly without clipping.
- I checked that `rmw_zenoh_cpp` does not have this bug — its `DataCallbackManager::set_callback()` passes `unread_count_` without depth clipping.
- Regression test included: publishes a transient-local message before the subscriber exists, subscribes with KEEP_ALL + transient-local via `EventsExecutor`, and asserts the cached message is delivered.

@doisyg FYI
