### PR TITLE
Fix memory leak when taking service responses addressed to other clients

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -79,7 +79,9 @@
 
 #include "rmw_security_common/security.hpp"
 
+#include "rosidl_runtime_c/message_initialization.h"
 #include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
@@ -4737,6 +4739,29 @@ static const std::string csid_to_string(const client_service_id_t & id)
   return os.str();
 }
 
+static void refini_message(
+  const rosidl_message_type_support_t * type_supports, void * message)
+{
+  const rosidl_message_type_support_t * ts;
+  if ((ts =
+    get_message_typesupport_handle(
+      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier)) != nullptr)
+  {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts->data);
+    members->fini_function(message);
+    members->init_function(message, rosidl_runtime_cpp::MessageInitialization::ALL);
+  } else if ((ts = // NOLINT
+    get_message_typesupport_handle(
+      type_supports, rosidl_typesupport_introspection_c__identifier)) != nullptr)
+  {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
+    members->fini_function(message);
+    members->init_function(message, ROSIDL_RUNTIME_C_MSG_INIT_ALL);
+  }
+}
+
 static rmw_ret_t rmw_take_response_request(
   CddsCS * cs, rmw_service_info_t * request_header,
   void * ros_data, bool * taken, dds_time_t * source_timestamp,
@@ -4773,6 +4798,7 @@ static rmw_ret_t rmw_take_response_request(
         *taken = true;
         return RMW_RET_OK;
       }
+      refini_message(&cs->sub->type_supports, ros_data);
     }
   }
   *taken = false;
@@ -5138,6 +5164,7 @@ static rmw_ret_t rmw_init_cs(
 
     sub_type_hash = type_supports->request_typesupport->get_type_hash_func(
       type_supports->request_typesupport);
+    sub->type_supports = *type_supports->request_typesupport;
     pub_type_hash = type_supports->response_typesupport->get_type_hash_func(
       type_supports->response_typesupport);
     subtopic_name =
@@ -5166,6 +5193,7 @@ static rmw_ret_t rmw_init_cs(
       type_supports->request_typesupport);
     sub_type_hash = type_supports->response_typesupport->get_type_hash_func(
       type_supports->response_typesupport);
+    sub->type_supports = *type_supports->response_typesupport;
     pubtopic_name =
       make_fqtopic(ROS_SERVICE_REQUESTER_PREFIX, service_name, "Request", qos_policies);
     subtopic_name = make_fqtopic(ROS_SERVICE_RESPONSE_PREFIX, service_name, "Reply", qos_policies);

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -362,6 +362,9 @@ struct CddsSubscription : CddsEntity
   rmw_gid_t gid;
   dds_entity_t rdcondh;
   rosidl_message_type_support_t type_supports;
+  // set only for client/service readers (rmw_init_cs): fini's and re-inits a
+  // taken message so the take loop can skip foreign replies without leaking
+  std::function<void(void *)> refini_message;
 #if CDDS_VERSION == CDDS_VERSION_0_10
   dds_data_allocator_t data_allocator;
 #endif
@@ -4739,26 +4742,27 @@ static const std::string csid_to_string(const client_service_id_t & id)
   return os.str();
 }
 
-static void refini_message(
-  const rosidl_message_type_support_t * type_supports, void * message)
+static std::function<void(void *)> make_refini_message(
+  const rosidl_message_type_support_t * type_supports)
 {
-  const rosidl_message_type_support_t * ts;
-  if ((ts =
-    get_message_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_cpp::typesupport_identifier)) != nullptr)
-  {
-    auto members =
-      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts->data);
-    members->fini_function(message);
-    members->init_function(message, rosidl_runtime_cpp::MessageInitialization::ALL);
-  } else if ((ts = // NOLINT
-    get_message_typesupport_handle(
-      type_supports, rosidl_typesupport_introspection_c__identifier)) != nullptr)
-  {
+  const rosidl_message_type_support_t * ts = get_typesupport(type_supports);
+  if (ts == nullptr) {
+    return nullptr;
+  }
+  if (strcmp(ts->typesupport_identifier, rosidl_typesupport_introspection_c__identifier) == 0) {
     auto members =
       static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
-    members->fini_function(message);
-    members->init_function(message, ROSIDL_RUNTIME_C_MSG_INIT_ALL);
+    return [members](void * message) {
+        members->fini_function(message);
+        members->init_function(message, ROSIDL_RUNTIME_C_MSG_INIT_ALL);
+      };
+  } else {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts->data);
+    return [members](void * message) {
+        members->fini_function(message);
+        members->init_function(message, rosidl_runtime_cpp::MessageInitialization::ALL);
+      };
   }
 }
 
@@ -4798,7 +4802,7 @@ static rmw_ret_t rmw_take_response_request(
         *taken = true;
         return RMW_RET_OK;
       }
-      refini_message(&cs->sub->type_supports, ros_data);
+      cs->sub->refini_message(ros_data);
     }
   }
   *taken = false;
@@ -5144,6 +5148,13 @@ static rmw_ret_t rmw_init_cs(
 
   auto pub = std::make_unique<CddsPublisher>();
   auto sub = std::make_unique<CddsSubscription>();
+  // the reader takes requests for a service, responses for a client; resolve
+  // its refini closure up front, while failing needs no cleanup yet
+  sub->refini_message = make_refini_message(
+    is_service ? type_supports->request_typesupport : type_supports->response_typesupport);
+  if (!sub->refini_message) {
+    return RMW_RET_ERROR;
+  }
   std::string subtopic_name, pubtopic_name;
   dds_qos_t * pub_qos, * sub_qos;
   const rosidl_type_hash_t * pub_type_hash;
@@ -5164,7 +5175,6 @@ static rmw_ret_t rmw_init_cs(
 
     sub_type_hash = type_supports->request_typesupport->get_type_hash_func(
       type_supports->request_typesupport);
-    sub->type_supports = *type_supports->request_typesupport;
     pub_type_hash = type_supports->response_typesupport->get_type_hash_func(
       type_supports->response_typesupport);
     subtopic_name =
@@ -5193,7 +5203,6 @@ static rmw_ret_t rmw_init_cs(
       type_supports->request_typesupport);
     sub_type_hash = type_supports->response_typesupport->get_type_hash_func(
       type_supports->response_typesupport);
-    sub->type_supports = *type_supports->response_typesupport;
     pubtopic_name =
       make_fqtopic(ROS_SERVICE_REQUESTER_PREFIX, service_name, "Request", qos_policies);
     subtopic_name = make_fqtopic(ROS_SERVICE_RESPONSE_PREFIX, service_name, "Reply", qos_policies);


### PR DESCRIPTION
## Description

rmw_take_response_request drains the reply reader in a loop, deserializing each sample into the same ros_data and skipping replies that belong to other clients of the same service (GUID mismatch). The message content of the skipped iteration was never finalized, so the next deserialization overwrote sequence/string pointers, leaking the payload. 

In our deployment, three services are polling the same ros image service; each service leaked ~13-30 mb/min. With these changes, ram usage is stable even after 5h


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

yes, was diagnosed and patch drafted with Claude code (Fable 5)

### Additional Information

The leak needs two or more processes holding clients for the same service - single-client tests never hit it, since the caller always frees the last deserialized sample
