### PR TITLE
Warn when system net.core.rmem_max is too low for CycloneDDS

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -14,7 +14,9 @@
 
 #include <cassert>
 #include <cstring>
+#ifdef __linux__
 #include <fstream>
+#endif
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -1387,20 +1389,22 @@ rmw_context_impl_s::init(rmw_init_options_t * options, size_t domain_id)
     return RMW_RET_OK;
   }
 
+#ifdef __linux__
   {
     std::ifstream rmem_max_file("/proc/sys/net/core/rmem_max");
     if (rmem_max_file.is_open()) {
-      unsigned long rmem_max = 0;
+      size_t rmem_max = 0;
       rmem_max_file >> rmem_max;
       if (rmem_max < 8388608) {
         RCUTILS_LOG_WARN_NAMED(
           "rmw_cyclonedds_cpp",
-          "system rmem_max (%lu) is lower than the recommended minimum of 8388608. "
+          "system rmem_max (%zu) is lower than the recommended minimum of 8388608. "
           "Increase it: sudo sysctl -w net.core.rmem_max=8388608",
           rmem_max);
       }
     }
   }
+#endif
 
   /* Take domains_lock and hold it until after the participant creation succeeded or
     failed: otherwise there is a race with rmw_destroy_node deleting the last participant

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -14,6 +14,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <fstream>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
@@ -1384,6 +1385,21 @@ rmw_context_impl_s::init(rmw_init_options_t * options, size_t domain_id)
     // initialization has already been done
     this->node_count++;
     return RMW_RET_OK;
+  }
+
+  {
+    std::ifstream rmem_max_file("/proc/sys/net/core/rmem_max");
+    if (rmem_max_file.is_open()) {
+      unsigned long rmem_max = 0;
+      rmem_max_file >> rmem_max;
+      if (rmem_max < 8388608) {
+        RCUTILS_LOG_WARN_NAMED(
+          "rmw_cyclonedds_cpp",
+          "system rmem_max (%lu) is lower than the recommended minimum of 8388608. "
+          "Increase it: sudo sysctl -w net.core.rmem_max=8388608",
+          rmem_max);
+      }
+    }
   }
 
   /* Take domains_lock and hold it until after the participant creation succeeded or


### PR DESCRIPTION
CycloneDDS needs sufficient kernel receive buffer space for reliable operation. The recommended minimum is 8388608 per the rmw_cyclonedds README.

Check /proc/sys/net/core/rmem_max at init time and emit a warning if the value is below the threshold. Only warns -- never modifies kernel settings.