### PR TITLE
Downgrade 'Failed to parse type hash' log from WARN to DEBUG

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -957,7 +957,7 @@ static void handle_builtintopic_endpoint(
         if (RMW_RET_OK != rmw_dds_common::parse_type_hash_from_user_data(
             reinterpret_cast<const uint8_t *>(userdata), userdata_size, type_hash))
         {
-          RCUTILS_LOG_WARN_NAMED(
+          RCUTILS_LOG_DEBUG_NAMED(
             "rmw_cyclonedds_cpp",
             "Failed to parse type hash for topic '%s' with type '%s' from USER_DATA '%*s'.",
             s->topic_name, s->type_name,


### PR DESCRIPTION
Downgrade "Failed to parse type hash for topic" from WARN to DEBUG.

The type hash parsing failure is a non-fatal compatibility case:
after logging and resetting the error, the endpoint is still added
to the graph cache. The implementation already treats this as non-fatal:
it resets the error, uses a zero-initialized type hash, and continues
graph discovery. Legacy ROS 2 and non-ROS DDS endpoints may legitimately
not provide ROS type-hash data. On heterogeneous ROS 2 systems with
endpoints that predate type hash support, this WARN fires per-endpoint
and floods the console with noise the user cannot act on.

This also aligns rmw_cyclonedds with ros2/rmw_connextdds#149,
which downgraded the equivalent diagnostic from WARN to DEBUG.

Fixes #567.
