### PR TITLE
[jazzy] Downgrade 'Failed to parse type hash' log from WARN to DEBUG (backport #591)

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -934,7 +934,7 @@ static void handle_builtintopic_endpoint(
         if (RMW_RET_OK != rmw_dds_common::parse_type_hash_from_user_data(
             reinterpret_cast<const uint8_t *>(userdata), userdata_size, type_hash))
         {
-          RCUTILS_LOG_WARN_NAMED(
+          RCUTILS_LOG_DEBUG_NAMED(
             "rmw_cyclonedds_cpp",
             "Failed to parse type hash for topic '%s' with type '%s' from USER_DATA '%*s'.",
             s->topic_name, s->type_name,


### PR DESCRIPTION
Backport of #591 to jazzy. Refs #567.

Downgrade "Failed to parse type hash for topic" from WARN to DEBUG.

The type hash parsing failure is a non-fatal compatibility case: after logging and resetting the error, the endpoint is still added to the graph cache with a zero-initialized type hash, and graph discovery continues. Legacy ROS 2 and non-ROS DDS endpoints (e.g. robot firmware publishing raw DDS topics) may legitimately not provide ROS type-hash data. On heterogeneous systems this WARN fires once per discovered endpoint per node and floods the console with noise the user cannot act on.

This also aligns rmw_cyclonedds with ros2/rmw_connextdds#149, which downgraded the equivalent diagnostic from WARN to DEBUG.

Motivation for the jazzy backport: interoperating with non-ROS CycloneDDS participants (Unitree Go2 firmware) on Jazzy produces dozens of these warnings on every node startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)