### PR TITLE
Fix subscription graph cleanup on destruction

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -3301,7 +3301,7 @@ extern "C" rmw_ret_t rmw_destroy_subscription(rmw_node_t * node, rmw_subscriptio
   rmw_error_string_t error_string;
   auto common = &node->context->impl->common;
   const auto cddssub = static_cast<const CddsSubscription *>(subscription->data);
-  ret = common->remove_publisher_graph(
+  ret = common->remove_subscriber_graph(
     cddssub->gid,
     node->name, node->namespace_);
   if (RMW_RET_OK != ret) {


### PR DESCRIPTION
## Description
rmw_destroy_subscription() incorrectly called remove_publisher_graph() with the subscription GID.
This operation is a no-op for reader entities and leaves stale subscriptions in the ROS graph cache.
Repeatedly creating and destroying subscriptions therefore caused the graph metadata to grow continuously and increased subscription creation latency.
Call remove_subscriber_graph() so the reader entity is correctly removed when the subscription is destroyed.
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?
no change
<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?
yes, was diagnosed and patch drafted with gpt-5.6
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
