### PR TITLE
Fix memory leak when taking service responses addressed to other clients

### DIFF
--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -78,7 +78,9 @@
 #include "rmw_dds_common/qos.hpp"
 #include "rmw_dds_common/security.hpp"
 
+#include "rosidl_runtime_c/message_initialization.h"
 #include "rosidl_runtime_c/type_hash.h"
+#include "rosidl_runtime_cpp/message_initialization.hpp"
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 
@@ -354,6 +356,7 @@ struct CddsSubscription : CddsEntity
   rmw_gid_t gid;
   dds_entity_t rdcondh;
   rosidl_message_type_support_t type_supports;
+  std::function<void(void *)> refini_message;
   dds_data_allocator_t data_allocator;
   bool is_loaning_available;
   user_callback_data_t user_callback_data;
@@ -4612,6 +4615,30 @@ static const std::string csid_to_string(const client_service_id_t & id)
   return os.str();
 }
 
+static std::function<void(void *)> make_refini_message(
+  const rosidl_message_type_support_t * type_supports)
+{
+  const rosidl_message_type_support_t * ts = get_typesupport(type_supports);
+  if (ts == nullptr) {
+    return nullptr;
+  }
+  if (strcmp(ts->typesupport_identifier, rosidl_typesupport_introspection_c__identifier) == 0) {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_c__MessageMembers *>(ts->data);
+    return [members](void * message) {
+        members->fini_function(message);
+        members->init_function(message, ROSIDL_RUNTIME_C_MSG_INIT_ALL);
+      };
+  } else {
+    auto members =
+      static_cast<const rosidl_typesupport_introspection_cpp::MessageMembers *>(ts->data);
+    return [members](void * message) {
+        members->fini_function(message);
+        members->init_function(message, rosidl_runtime_cpp::MessageInitialization::ALL);
+      };
+  }
+}
+
 static rmw_ret_t rmw_take_response_request(
   CddsCS * cs, rmw_service_info_t * request_header,
   void * ros_data, bool * taken, dds_time_t * source_timestamp,
@@ -4648,6 +4675,7 @@ static rmw_ret_t rmw_take_response_request(
         *taken = true;
         return RMW_RET_OK;
       }
+      cs->sub->refini_message(ros_data);
     }
   }
   *taken = false;
@@ -4952,6 +4980,11 @@ static rmw_ret_t rmw_init_cs(
 
   auto pub = std::make_unique<CddsPublisher>();
   auto sub = std::make_unique<CddsSubscription>();
+  sub->refini_message = make_refini_message(
+    is_service ? type_supports->request_typesupport : type_supports->response_typesupport);
+  if (!sub->refini_message) {
+    return RMW_RET_ERROR;
+  }
   std::string subtopic_name, pubtopic_name;
   void * pub_type_support, * sub_type_support;
   dds_qos_t * pub_qos, * sub_qos;


### PR DESCRIPTION
## Description

rmw_take_response_request drains the reply reader in a loop, deserializing each sample into the same ros_data and skipping replies that belong to other clients of the same service (GUID mismatch). The message content of the skipped iteration was never finalized, so the next deserialization overwrote sequence/string pointers, leaking the payload. 

In our deployment, three services are polling the same ros image service; each service leaked ~13-30 mb/min. With these changes, ram usage is stable even after 5h


### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

yes, was diagnosed and patch drafted with Claude code (Fable 5)

### Additional Information

The leak needs two or more processes holding clients for the same service - single-client tests never hit it, since the caller always frees the last deserialized sample
