### PR TITLE
print rmem warning per-process, and adjust the output filter.

### DIFF
--- a/rmw_cyclonedds_cpp/cmake/get_rmw_cyclonedds_output_filter.cmake
+++ b/rmw_cyclonedds_cpp/cmake/get_rmw_cyclonedds_output_filter.cmake
@@ -27,5 +27,7 @@ macro(get_rmw_cyclonedds_output_filter output_patterns)
       "unused arguments: ${ARGN}")
   endif()
 
-  set(${output_patterns} ".*using network interface \\w+ \\(.*\\) selected arbitrarily from:.*")
+  string(CONCAT ${output_patterns}
+    ".*using network interface \\w+ \\(.*\\) selected arbitrarily from:.*\n"
+    ".*system rmem_max \\([0-9]+\\) is lower than the recommended minimum.*")
 endmacro()

--- a/rmw_cyclonedds_cpp/src/rmw_node.cpp
+++ b/rmw_cyclonedds_cpp/src/rmw_node.cpp
@@ -1391,18 +1391,23 @@ rmw_context_impl_s::init(rmw_init_options_t * options, size_t domain_id)
 
 #ifdef __linux__
   {
-    std::ifstream rmem_max_file("/proc/sys/net/core/rmem_max");
-    if (rmem_max_file.is_open()) {
-      size_t rmem_max = 0;
-      rmem_max_file >> rmem_max;
-      if (rmem_max < 8388608) {
-        RCUTILS_LOG_WARN_NAMED(
-          "rmw_cyclonedds_cpp",
-          "system rmem_max (%zu) is lower than the recommended minimum of 8388608. "
-          "Increase it: sudo sysctl -w net.core.rmem_max=8388608",
-          rmem_max);
-      }
-    }
+    // rmem_max is a system-wide setting, so warn only once per process
+    static std::once_flag rmem_max_warn_once;
+    std::call_once(
+      rmem_max_warn_once, []() {
+        std::ifstream rmem_max_file("/proc/sys/net/core/rmem_max");
+        if (rmem_max_file.is_open()) {
+          size_t rmem_max = 0;
+          rmem_max_file >> rmem_max;
+          if (rmem_max < 8388608) {
+            RCUTILS_LOG_WARN_NAMED(
+              "rmw_cyclonedds_cpp",
+              "system rmem_max (%zu) is lower than the recommended minimum of 8388608. "
+              "Increase it: sudo sysctl -w net.core.rmem_max=8388608",
+              rmem_max);
+          }
+        }
+      });
   }
 #endif
 


### PR DESCRIPTION
## Description

address regression generated by https://github.com/ros2/rmw_cyclonedds/pull/590

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #601 

### Is this user-facing behavior change?

Not really, now the warning is printed only per-process. (and this is likely the case.)

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

Yes, Claude Fable 5

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
