### PR TITLE
Add CPU fallback support for rosidl::Buffer

### DIFF
--- a/rmw_cyclonedds_cpp/CMakeLists.txt
+++ b/rmw_cyclonedds_cpp/CMakeLists.txt
@@ -48,6 +48,7 @@ endif()
 find_package(rmw REQUIRED)
 find_package(rmw_dds_common REQUIRED)
 find_package(rmw_security_common REQUIRED)
+find_package(rosidl_buffer REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 find_package(rosidl_typesupport_introspection_c REQUIRED)
 find_package(rosidl_typesupport_introspection_cpp REQUIRED)
@@ -62,6 +63,7 @@ ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_runtime_c)
 ament_export_dependencies(rmw_dds_common)
 ament_export_dependencies(rmw_security_common)
+ament_export_dependencies(rosidl_buffer)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)
 ament_export_dependencies(tracetools)
@@ -91,6 +93,7 @@ target_link_libraries(rmw_cyclonedds_cpp PRIVATE
   rcpputils::rcpputils
   rmw_dds_common::rmw_dds_common_library
   rmw_security_common::rmw_security_common_library
+  rosidl_buffer::rosidl_buffer
   rosidl_typesupport_introspection_c::rosidl_typesupport_introspection_c
   rosidl_typesupport_introspection_cpp::rosidl_typesupport_introspection_cpp
   rosidl_runtime_c::rosidl_runtime_c

--- a/rmw_cyclonedds_cpp/package.xml
+++ b/rmw_cyclonedds_cpp/package.xml
@@ -22,6 +22,7 @@
   <depend>rmw</depend>
   <depend>rmw_dds_common</depend>
   <depend>rmw_security_common</depend>
+  <depend>rosidl_buffer</depend>
   <depend>rosidl_runtime_c</depend>
   <depend>rosidl_typesupport_introspection_c</depend>
   <depend>rosidl_typesupport_introspection_cpp</depend>

--- a/rmw_cyclonedds_cpp/src/Serialization.cpp
+++ b/rmw_cyclonedds_cpp/src/Serialization.cpp
@@ -511,8 +511,15 @@ protected:
   {
     size_t count = value_type.sequence_size(src);
     serialize_u32(dst, count);
+    std::vector<uint8_t> cpu_storage;
+    const bool data_required = !dst.ignores_data();
+    const void * contents =
+      value_type.serialization_contents(src, cpu_storage, data_required);
+    if (data_required && contents == cpu_storage.data() && cpu_storage.size() != count) {
+      throw std::runtime_error("rosidl buffer size changed during CPU fallback conversion");
+    }
     serialize_many(
-      dst, value_type.sequence_contents(src), count, value_type.element_value_type(), what);
+      dst, contents, count, value_type.element_value_type(), what);
   }
 
   template<typename WriteCursor>

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.cpp
@@ -19,13 +19,177 @@
 #include <vector>
 
 #include "rcutils/error_handling.h"
+#include "rosidl_buffer/buffer.hpp"
 #include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/primitives_sequence.h"
+#include "rosidl_runtime_c/primitives_sequence_functions.h"
 #include "rosidl_runtime_c/service_type_support_struct.h"
 
 namespace rmw_cyclonedds_cpp
 {
 const PrimitiveValueType primitive_value_type_boolean =
   PrimitiveValueType(ROSIDL_TypeKind::BOOLEAN);
+
+namespace
+{
+
+using UInt8Buffer = rosidl::Buffer<uint8_t>;
+
+bool is_cpu_buffer(const UInt8Buffer & buffer)
+{
+  return dynamic_cast<const rosidl::CpuBufferImpl<uint8_t> *>(buffer.get_impl()) != nullptr;
+}
+
+const void * buffer_serialization_contents(
+  const UInt8Buffer & buffer, std::vector<uint8_t> & cpu_storage)
+{
+  if (is_cpu_buffer(buffer)) {
+    return buffer.data();
+  }
+  cpu_storage = buffer.to_vector();
+  return cpu_storage.data();
+}
+
+class ROSIDLCPP_BufferSequenceValueType : public SpanSequenceValueType
+{
+  const AnyValueType * m_element_value_type;
+
+  static const UInt8Buffer * get_value(const void * ptr_to_sequence)
+  {
+    return static_cast<const UInt8Buffer *>(ptr_to_sequence);
+  }
+
+  static UInt8Buffer * get_value(void * ptr_to_sequence)
+  {
+    return static_cast<UInt8Buffer *>(ptr_to_sequence);
+  }
+
+public:
+  explicit ROSIDLCPP_BufferSequenceValueType(
+    const AnyValueType * element_value_type, uint32_t bound)
+  : SpanSequenceValueType(bound), m_element_value_type(element_value_type)
+  {
+    assert(m_element_value_type);
+  }
+
+  size_t sizeof_type() const override {return sizeof(UInt8Buffer);}
+  size_t cdrsizeof_type() const override {throw std::logic_error("not implemented");}
+  size_t cdralignof_type() const override {throw std::logic_error("not implemented");}
+  const AnyValueType * element_value_type() const override {return m_element_value_type;}
+  size_t sequence_size(const void * ptr_to_sequence) const override
+  {
+    return get_value(ptr_to_sequence)->size();
+  }
+  const void * sequence_contents(const void * ptr_to_sequence) const override
+  {
+    return get_value(ptr_to_sequence)->data();
+  }
+  const void * serialization_contents(
+    const void * ptr_to_sequence, std::vector<uint8_t> & cpu_storage,
+    bool data_required) const override
+  {
+    if (!data_required) {
+      return nullptr;
+    }
+    return buffer_serialization_contents(*get_value(ptr_to_sequence), cpu_storage);
+  }
+  void * sequence_contents(void * ptr_to_sequence) const override
+  {
+    return get_value(ptr_to_sequence)->data();
+  }
+  void resize(void * ptr_to_sequence, size_t size) const override
+  {
+    auto & buffer = *get_value(ptr_to_sequence);
+    if (is_cpu_buffer(buffer)) {
+      buffer.resize(size);
+    } else {
+      buffer = UInt8Buffer(size);
+    }
+  }
+};
+
+class ROSIDLC_BufferSequenceValueType : public SpanSequenceValueType
+{
+  const AnyValueType * m_element_value_type;
+
+  static const rosidl_runtime_c__uint8__Sequence * get_value(const void * ptr_to_sequence)
+  {
+    return static_cast<const rosidl_runtime_c__uint8__Sequence *>(ptr_to_sequence);
+  }
+
+  static rosidl_runtime_c__uint8__Sequence * get_value(void * ptr_to_sequence)
+  {
+    return static_cast<rosidl_runtime_c__uint8__Sequence *>(ptr_to_sequence);
+  }
+
+  static const UInt8Buffer * get_buffer(const rosidl_runtime_c__uint8__Sequence & sequence)
+  {
+    return reinterpret_cast<const UInt8Buffer *>(sequence.data);
+  }
+
+  static UInt8Buffer * get_buffer(rosidl_runtime_c__uint8__Sequence & sequence)
+  {
+    return reinterpret_cast<UInt8Buffer *>(sequence.data);
+  }
+
+public:
+  explicit ROSIDLC_BufferSequenceValueType(
+    const AnyValueType * element_value_type, uint32_t bound)
+  : SpanSequenceValueType(bound), m_element_value_type(element_value_type)
+  {
+    assert(m_element_value_type);
+  }
+
+  size_t sizeof_type() const override {return sizeof(rosidl_runtime_c__uint8__Sequence);}
+  size_t cdrsizeof_type() const override {throw std::logic_error("not implemented");}
+  size_t cdralignof_type() const override {throw std::logic_error("not implemented");}
+  const AnyValueType * element_value_type() const override {return m_element_value_type;}
+  size_t sequence_size(const void * ptr_to_sequence) const override
+  {
+    const auto & sequence = *get_value(ptr_to_sequence);
+    return sequence.is_rosidl_buffer ? get_buffer(sequence)->size() : sequence.size;
+  }
+  const void * sequence_contents(const void * ptr_to_sequence) const override
+  {
+    const auto & sequence = *get_value(ptr_to_sequence);
+    return sequence.is_rosidl_buffer ? get_buffer(sequence)->data() : sequence.data;
+  }
+  const void * serialization_contents(
+    const void * ptr_to_sequence, std::vector<uint8_t> & cpu_storage,
+    bool data_required) const override
+  {
+    if (!data_required) {
+      return nullptr;
+    }
+    const auto & sequence = *get_value(ptr_to_sequence);
+    if (sequence.is_rosidl_buffer) {
+      return buffer_serialization_contents(*get_buffer(sequence), cpu_storage);
+    }
+    return sequence.data;
+  }
+  void * sequence_contents(void * ptr_to_sequence) const override
+  {
+    auto & sequence = *get_value(ptr_to_sequence);
+    return sequence.is_rosidl_buffer ? get_buffer(sequence)->data() : sequence.data;
+  }
+  void resize(void * ptr_to_sequence, size_t size) const override
+  {
+    auto * sequence = get_value(ptr_to_sequence);
+    rosidl_runtime_c__uint8__Sequence__fini(sequence);
+    if (!rosidl_runtime_c__uint8__Sequence__init(sequence, size)) {
+      throw std::bad_alloc();
+    }
+  }
+};
+
+void validate_buffer_member(ROSIDL_TypeKind type_kind, bool is_array)
+{
+  if (!is_array || type_kind != ROSIDL_TypeKind::UINT8) {
+    throw std::logic_error("rosidl buffer fields must be uint8 sequences");
+  }
+}
+
+}  // namespace
 
 class ROSIDLC_StructValueType : public StructValueType
 {
@@ -189,7 +353,11 @@ ROSIDLC_StructValueType::ROSIDLC_StructValueType(
     if (member_impl.is_array_ && member_impl.array_size_ != 0 && member_impl.is_upper_bound_) {
       bound = static_cast<uint32_t>(member_impl.array_size_);
     }
-    if (!member_impl.is_array_) {
+    if (member_impl.is_rosidl_buffer_) {
+      validate_buffer_member(ROSIDL_TypeKind(member_impl.type_id_), member_impl.is_array_);
+      member_value_type = make_value_type<ROSIDLC_BufferSequenceValueType>(
+        element_value_type, bound);
+    } else if (!member_impl.is_array_) {
       member_value_type = element_value_type;
     } else if (member_impl.array_size_ != 0 && !member_impl.is_upper_bound_) {
       member_value_type = make_value_type<ArrayValueType>(
@@ -263,7 +431,11 @@ ROSIDLCPP_StructValueType::ROSIDLCPP_StructValueType(
     if (member_impl.is_array_ && member_impl.array_size_ != 0 && member_impl.is_upper_bound_) {
       bound = static_cast<uint32_t>(member_impl.array_size_);
     }
-    if (!member_impl.is_array_) {
+    if (member_impl.is_rosidl_buffer_) {
+      validate_buffer_member(ROSIDL_TypeKind(member_impl.type_id_), member_impl.is_array_);
+      member_value_type = make_value_type<ROSIDLCPP_BufferSequenceValueType>(
+        element_value_type, bound);
+    } else if (!member_impl.is_array_) {
       member_value_type = element_value_type;
     } else if (member_impl.array_size_ != 0 && !member_impl.is_upper_bound_) {
       member_value_type = make_value_type<ArrayValueType>(

--- a/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
+++ b/rmw_cyclonedds_cpp/src/TypeSupport2.hpp
@@ -261,6 +261,14 @@ public:
   virtual const AnyValueType * element_value_type() const = 0;
   virtual size_t sequence_size(const void * ptr_to_sequence) const = 0;
   virtual const void * sequence_contents(const void * ptr_to_sequence) const = 0;
+  virtual const void * serialization_contents(
+    const void * ptr_to_sequence, std::vector<uint8_t> & cpu_storage,
+    bool data_required) const
+  {
+    (void)cpu_storage;
+    (void)data_required;
+    return sequence_contents(ptr_to_sequence);
+  }
   virtual void * sequence_contents(void * ptr_to_sequence) const = 0;
   virtual void resize(void * ptr_to_sequence, size_t size) const = 0;
   uint32_t sequence_bound() const {return m_bound;}

--- a/rmw_cyclonedds_cpp/src/serdata.cpp
+++ b/rmw_cyclonedds_cpp/src/serdata.cpp
@@ -144,7 +144,7 @@ static void serdata_rmw_set_key_from_ser(serdata_rmw * d)
   }
 }
 
-static void serdata_rmw_serialize_into(serdata_rmw * d, const void * sample)
+static bool serdata_rmw_serialize_into(serdata_rmw * d, const void * sample)
 {
   auto type = static_cast<const struct sertype_rmw *>(d->type);
   try {
@@ -153,8 +153,11 @@ static void serdata_rmw_serialize_into(serdata_rmw * d, const void * sample)
     size_t sz = type->cdr_writer->get_serialized_size(sample, cdrmode);
     d->resize(sz);
     type->cdr_writer->serialize(d->data(), sample, cdrmode);
+    return true;
   } catch (std::exception & e) {
+    d->resize(0);
     RMW_SET_ERROR_MSG(e.what());
+    return false;
   }
 }
 
@@ -169,7 +172,7 @@ static void serdata_rmw_serialize_into_on_demand(serdata_rmw * d)
         d->resize(d->loan->metadata->sample_size);
         memcpy(d->data(), d->loan->sample_ptr, d->loan->metadata->sample_size);
       } else if (d->loan->metadata->sample_state == DDS_LOANED_SAMPLE_STATE_RAW_DATA) {
-        serdata_rmw_serialize_into(d, d->loan->sample_ptr);
+        (void)serdata_rmw_serialize_into(d, d->loan->sample_ptr);
       } else {
         RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
       }
@@ -186,7 +189,7 @@ static void serdata_rmw_serialize_into_on_demand(serdata_rmw * d)
         d->resize(iox_header->data_size);
         memcpy(d->data(), d->iox_chunk, iox_header->data_size);
       } else if (iox_header->shm_data_state == IOX_CHUNK_CONTAINS_RAW_DATA) {
-        serdata_rmw_serialize_into(d, d->iox_chunk);
+        (void)serdata_rmw_serialize_into(d, d->iox_chunk);
       } else {
         RMW_SET_ERROR_MSG("Received iox chunk is uninitialized");
       }
@@ -299,7 +302,9 @@ static std::unique_ptr<serdata_rmw> serdata_rmw_from_sample_unique(
     auto type = static_cast<const struct sertype_rmw *>(typecmn);
     auto d = std::make_unique<serdata_rmw>(type, kind);
     serdata_rmw_set_key_from_sample(d.get(), sample);
-    serdata_rmw_serialize_into(d.get(), sample);
+    if (!serdata_rmw_serialize_into(d.get(), sample)) {
+      return nullptr;
+    }
     return d;
   } catch (std::exception & e) {
     RMW_SET_ERROR_MSG(e.what());
@@ -727,6 +732,7 @@ static bool sertype_serialize_into_impl(
     type->cdr_writer->serialize(dst_buffer, sample, rmw_cyclonedds_cpp::SampleOrKey::Sample);
   } catch (std::exception & e) {
     RMW_SET_ERROR_MSG(e.what());
+    return false;
   }
   return true;
 }


### PR DESCRIPTION
## Description

  Add CPU fallback support for rosidl buffer fields to `rmw_cyclonedds_cpp`.

  CycloneDDS uses rosidl introspection to serialize messages. Previously, serialization accessed buffer fields through their CPU-only sequence callbacks. Publishing a message containing a non-CPU-backed
  `rosidl::Buffer<uint8_t>` therefore failed instead of falling back to the standard DDS wire representation.

  This change:

  - Detects rosidl buffer fields through introspection metadata.
  - Supports both introspection C++ and introspection C message representations.
  - Keeps the existing direct serialization path for CPU-backed buffers.
  - Converts non-CPU buffers to a temporary CPU-owned `std::vector<uint8_t>` using `to_vector()` during serialization.
  - Does not mutate the message or replace its original backend while publishing.
  - Deserializes received buffer fields into owned CPU storage.
  - Replaces a non-CPU-backed destination buffer with CPU storage when deserializing into a reused message.
  - Reports serialization failure when backend-to-CPU conversion fails, instead of emitting a partial or malformed sample.
  - Adds the required dependency on `rosidl_buffer`.

  This implements CPU fallback only. It does not add backend metadata discovery or direct transport of backend-specific buffer representations.

  ### Is this user-facing behavior change?

  Yes.

  Applications using `rmw_cyclonedds_cpp` can now publish messages containing non-CPU-backed rosidl buffers. The buffer is converted to CPU memory for standard DDS serialization, and subscribers receive a
  CPU-backed buffer with the same contents.

  CPU-backed messages continue to use the direct serialization path without an additional fallback copy.

  ### Did you use Generative AI?

  Yes. OpenAI Codex (GPT-5) was used to draft the changes in this pull request.

  ### Additional Information

  The implementation relies on the existing rosidl buffer API and introspection metadata, including `rosidl::Buffer<uint8_t>` and the `is_rosidl_buffer` field marker.